### PR TITLE
Set required field `hrid` to unique value UITEST-50

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -78,6 +78,7 @@ module.exports.getUsers = (nightmare, config, done) => function getu() {
 
 module.exports.createInventory = (nightmare, config, title, holdingsOnly) => {
   const ti = title || 'New test title';
+  const id = new Date().valueOf();
   const barcode = new Date().valueOf();
   if (!holdingsOnly) {
     it('should create inventory record', (done) => {
@@ -87,6 +88,7 @@ module.exports.createInventory = (nightmare, config, title, holdingsOnly) => {
         .click('#clickable-newinventory')
         .wait('#input_instance_title')
         .insert('#input_instance_title', ti)
+        .insert('input[name=hrid]', id)
         .type('#select_instance_type', 'o')
         .click('#clickable-create-instance')
         .waitUntilNetworkIdle(500)


### PR DESCRIPTION
I expect the helper function createInventory in stripes-testing will fail due to a newly introduced mandatory field in ui-inventory Instance form. 

Something like this PR is probably needed to set the field and make tests using this helper pass. 