### PR TITLE
integration tests must accommodate MCL aria changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-testing
 
+## 1.2.0 (IN PROGRESS)
+
+* Update integration tests to accommodate MCL aria changes. Fixes UITEST-58.
+
+
 ## [1.1.0](https://github.com/folio-org/stripes-testing/tree/v1.1.0) (2018-11-30)
 * Upgrade `debug` dependency, STRIPES-553
 * New `.input(selector, stringToType)` action

--- a/helpers.js
+++ b/helpers.js
@@ -59,10 +59,18 @@ module.exports.openApp = (nightmare, config, done, app, testVersion) => function
 module.exports.getUsers = (nightmare, config, done) => function getu() {
   nightmare
     .click('#clickable-users-module')
-    .wait('#list-users div[role="listitem"]')
+    .wait('#clickable-filter-pg-faculty')
+    .click('#clickable-filter-pg-faculty')
+    .wait('#clickable-filter-pg-graduate')
+    .click('#clickable-filter-pg-graduate')
+    .wait('#clickable-filter-pg-staff')
+    .click('#clickable-filter-pg-staff')
+    .wait('#clickable-filter-pg-undergrad')
+    .click('#clickable-filter-pg-undergrad')
+    .wait('#list-users:not([data-total-count="0"])')
     .evaluate(() => {
       const udata = [];
-      const users = document.querySelectorAll('#list-users div[role="listitem"]');
+      const users = document.querySelectorAll('#list-users div[role="row"]');
       for (let x = 0; x < users.length; x++) {
         const st = users[x].querySelector('div:nth-of-type(1)').innerText;
         const nm = users[x].querySelector('div:nth-of-type(2)').innerText;


### PR DESCRIPTION
Changes to the aria attributes in MCL must be reflected in the
integration tests as well.

Refs [UITEST-58](https://issues.folio.org/browse/UITEST-58), [STCOM-365](https://issues.folio.org/browse/STCOM-365)