### PR TITLE
use always-available settings identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.0 (IN PROGRESS)
 
 * Update integration tests to accommodate MCL aria changes. Fixes UITEST-58.
-
+* Update integration tests to use always-available settings button. Refs STRIPES-606.
 
 ## [1.1.0](https://github.com/folio-org/stripes-testing/tree/v1.1.0) (2018-11-30)
 * Upgrade `debug` dependency, STRIPES-553

--- a/folio-ui.config.js
+++ b/folio-ui.config.js
@@ -14,7 +14,7 @@ module.exports = {
     password: '#input-password',
     login: '#clickable-login',
     logout: '#clickable-logout',
-    settings: '#clickable-settings',
+    settings: '#app-list-item-clickable-settings',
   },
   nightmare: process.env.FOLIO_UI_DEBUG == 2 ? {
     openDevTools: {

--- a/helpers.js
+++ b/helpers.js
@@ -171,7 +171,7 @@ module.exports.circSettingsCheckoutByBarcodeAndUsername = (nightmare, config, do
   nightmare
     .wait(config.select.settings)
     .click(config.select.settings)
-    .wait('#clickable-settings')
+    .wait('#app-list-item-clickable-settings')
     .wait('a[href="/settings/circulation"]')
     .click('a[href="/settings/circulation"]')
     .wait('a[href="/settings/circulation/checkout"]')


### PR DESCRIPTION
The `clickable-settings` button may not always be available in the UI.
Specifically if there are more than 11 apps in the bundle, then it will
not be available. But there's still hope! The element in the apps menu
_is_ always available, and this change updates tests to find that
element instead.

Refs [STRIPES-606](https://issues.folio.org/browse/STRIPES-606)