### PR TITLE
clickApp/clickSettings: Changed signature to regular function

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -240,7 +240,7 @@ module.exports.setUsEnglishLocale = (nightmare, config, done) => {
  * buttons which are only available for the first 12 apps in the platform's
  * stripes.config.js file.
  */
-module.exports.clickApp = (nightmare, config, done, app) => function opena() {
+module.exports.clickApp = (nightmare, done, app) => {
   nightmare
     .wait(`#app-list-item-clickable-${app}-module`)
     .click(`#app-list-item-clickable-${app}-module`)
@@ -262,7 +262,7 @@ module.exports.clickApp = (nightmare, config, done, app) => function opena() {
  * button which will not be instantiated if there are 12 or more apps
  * in the platform's stripes.config.js file that th
  */
-module.exports.clickSettings = (nightmare, config, done) => function opena() {
+module.exports.clickSettings = (nightmare, done) => {
   nightmare
     .wait('#app-list-item-clickable-settings')
     .click('#app-list-item-clickable-settings')


### PR DESCRIPTION
The original signature of the functions was such that they returned functions. This is expected if they're to be used with `.use()`. However, the fact that they take and resolve a `done` Promise means that we can't actually chain them with `use()` - they need to be the last item _anyway_.

So I putzed around trying to get them to work correctly with `use` so that nightmare would let me do something like `.use(helpers.clickApp).click('#button-foo')` but I could never sort it out to a place where that was possible. 

So because of that, I'm just dropping these down to regular functions so that they're usage is clearer and cleaner.