### PR TITLE
remove unused mocha deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-testing
 
+## 1.3.0 (IN PROGRESS)
+
+* Remove unused mocha deps. Refs STCOR-611.
+
 ## [1.2.0](https://github.com/folio-org/stripes-testing/tree/v1.2.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v1.1.0...v1.2.0)
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   "dependencies": {
     "debug": "^4.0.1",
     "minimist": "^1.2.0",
-    "mocha": "^3.4.2",
-    "mocha-jenkins-reporter": "^0.3.12",
     "nightmare": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
        A long time ago
        in a repository
       far, far away ...

         STRIPES  FORCE
          EPISODE DCXI

It is a period of security concerns
for the consortium. Brave developers,
committing from Canada, have closed
most of the known vulnerabilities.

A lone dependency, held over from
an earlier age before a library was
converted from a framework, remains
and causes warnings.

With that dependency removed, the
package will be from from known
vulnerabilities and there will be
security in the repository...

Refs [STRIPES-611](https://issues.folio.org/browse/STRIPES-611)