### PR TITLE
remove xclick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-testing
 
+## 1.6.0 (IN PROGRESS)
+
+* Remove `xclick`; it was too likely to confound Nightmare.
+
 ## [1.5.0](https://github.com/folio-org/stripes-testing/tree/v1.5.0) (2019-05-15)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v1.4.0...v1.5.0)
 

--- a/xnightmare.js
+++ b/xnightmare.js
@@ -2,20 +2,6 @@
 Nightmare = require('nightmare');
 const debug = require('debug')('nightmare:actions');
 
-Nightmare.action('xclick', function xclick(selector, done) {
-  debug(`.xclick() on ${selector}`);
-  this.evaluate_now((select) => {
-    document.activeElement.blur();
-    const element = document.evaluate(select, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-    if (!element) {
-      throw new Error(`Unable to find element by selector: ${select}`);
-    }
-    const event = document.createEvent('MouseEvent');
-    event.initEvent('click', true, true);
-    element.dispatchEvent(event);
-  }, done, selector);
-});
-
 Nightmare.action('xtract', function xtract(selector, done) {
   debug(`.xtract() on ${selector}`);
   this.evaluate_now((select) => {


### PR DESCRIPTION
`xclick` triggered events outside the context of Nightmare itself and
that never worked reliably. It seemed to send Nightmare off into some
neverneverland of parallel execution that it could never return from.