### PR TITLE
bump Nightmare to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove `xclick`; it was too likely to confound Nightmare.
 * Add `checkout` and `setCirculationRules` helpers.
+* Bump Nightmare to 3.0.2 to avoid security issues.
 
 ## [1.5.0](https://github.com/folio-org/stripes-testing/tree/v1.5.0) (2019-05-15)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v1.4.0...v1.5.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-testing",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Regression tests for FOLIO UI",
   "repository": "folio-org/stripes-testing",
   "publishConfig": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "debug": "^4.0.1",
     "minimist": "^1.2.0",
-    "nightmare": "^3.0.1"
+    "nightmare": "^3.0.2"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",


### PR DESCRIPTION
Version 3.0.2 uses Electron `^2.0.18`; earlier versions have a security
vulnerability. Thanks, @julianladisch!