### PR TITLE
update item-form selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-testing
 
+## 1.6.2 (IN PROGRESS)
+
+* Update selector for create-item form.
+
 ## [1.6.1](https://github.com/folio-org/stripes-testing/tree/v1.6.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v1.6.0...v1.6.1)
 

--- a/helpers.js
+++ b/helpers.js
@@ -166,8 +166,8 @@ module.exports.createInventory = (nightmare, config, title, holdingsOnly) => {
           .select('#additem_materialType', mtypeid)
           // it is IMPERATIVE that interaction with a non-select component
           // immediately follows select(). See UIIN-671 for details.
-          .wait('input[name=copyNumbers]')
-          .insert('input[name=copyNumbers]', 1)
+          .wait('input[name="copyNumbers[0]"]')
+          .insert('input[name="copyNumbers[0]"]', 1)
           .evaluate(() => {
             const node = Array.from(
               document.querySelectorAll('#additem_loanTypePerm option')


### PR DESCRIPTION
The `copyNumbers` field is now presented as an array, not a scalar, so
the new-item helper needs to reflect that.