### PR TITLE
UITEST-69 prefer semantic over markup selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-testing
 
+## 1.6.5 IN PROGRESS
+
+* Prefer semantic over markup selectors; they are maaaaybe more reliable. Refs UITEST-69.
+
 ## [1.6.4](https://github.com/folio-org/stripes-testing/tree/v1.6.4) (2019-09-16)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v1.6.3...v1.6.4)
 

--- a/helpers.js
+++ b/helpers.js
@@ -175,7 +175,7 @@ module.exports.createInventory = (nightmare, config, title, holdingsOnly) => {
       .wait('#clickable-new-item')
       .click('#clickable-new-item')
       .wait('#additem_barcode')
-      // Why, why `type` instead of `insert`? why type in this, THE MOST
+      // Why, why `type` instead of `insert`? Why `type` in this, THE MOST
       // UNRELIABLE of tests? Because `insert` fails consistently, that's
       // why. Fails how? Like this: nothing happens, that's how. What do I
       // mean, "nothing"? NOTHING. NOTHING HAPPENS. You can log things with
@@ -249,7 +249,7 @@ module.exports.createInventory = (nightmare, config, title, holdingsOnly) => {
           .wait(() => !document.querySelector('#clickable-create-item'))
           .wait('#list-items')
           .wait(bc => {
-            return !!(Array.from(document.querySelectorAll('#list-items span'))
+            return !!(Array.from(document.querySelectorAll('#list-items [role=gridcell]'))
               .find(e => `${bc}` === e.textContent)); // `${}` forces string interpolation for numeric barcodes
           }, barcode)
           .then(done)


### PR DESCRIPTION
Semantic selectors appear to be more reliable than markup selectors for
this test.

Refs [UITEST-69](https://issues.folio.org/browse/UITEST-69)