### PR TITLE
FOLIO-2248 avoid copy-number in inventory-helper

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -223,8 +223,8 @@ module.exports.createInventory = (nightmare, config, title, holdingsOnly) => {
           .select('#additem_materialType', mtypeid)
           // it is IMPERATIVE that interaction with a non-select component
           // immediately follows select(). See UIIN-671 for details.
-          .wait('input[name="copyNumbers[0]"]')
-          .insert('input[name="copyNumbers[0]"]', 1)
+          .wait('#additem_numberofpieces')
+          .insert('#additem_numberofpieces', 1)
           .evaluate(() => {
             const node = Array.from(
               document.querySelectorAll('#additem_loanTypePerm option')


### PR DESCRIPTION
The copy-number field has changed in recent versions between being
repeatable and not. In order to continue using this helper with some
older platforms, we need to avoid interacting with that field because
the selectors for the old and new versions are different, meaning the
test will fail against either the old and new platform. Pity, given that
the only reason this field is in here at all is UITEST-68.

Refs [FOLIO-2248](https://issues.folio.org/browse/FOLIO-2248), [UITEST-68](https://issues.folio.org/browse/UITEST-68)