### PR TITLE
UITEST-70 be less markupy, more semantic

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -603,7 +603,7 @@ module.exports.checkout = (nightmare, done, itemBarcode, userBarcode) => {
     .click('#clickable-add-item')
     .wait('#list-items-checked-out')
     .wait(bc => {
-      return !!(Array.from(document.querySelectorAll('#list-items-checked-out div[role="row"] div[role="gridcell"]'))
+      return !!(Array.from(document.querySelectorAll('#list-items-checked-out [role="row"] [role="gridcell"]'))
         .find(e => `${bc}` === e.textContent)); // `${}` forces string interpolation for numeric barcodes
     }, itemBarcode)
     .then(done)


### PR DESCRIPTION
Nightmare appears to be getting hung up in some MCL selections. I'm not
sure how this is coming up now given that this passed for several days,
but here we are. Removing some of the markup and leaving the selector to
stand on semantic markup alone seems to do the trick.

Refs [UITEST-70](https://issues.folio.org/browse/UITEST-70)