### PR TITLE
Update test helpers to work with new main nav changes in stripes-core

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -40,7 +40,7 @@ module.exports.openApp = (nightmare, config, done, app, testVersion) => function
     .wait(`#${app}-module-display`)
     .exists('#app-list-dropdown-toggle[aria-expanded="true"]')
     .then(dropdownOpen => {
-      return dropdownOpen ? nightmare.click('#app-list-dropdown-toggle') : nightmare.wait(0);
+      return dropdownOpen ? nightmare.click('#app-list-dropdown-toggle').wait('#app-list-dropdown-toggle[aria-expanded="false"]') : nightmare.wait(0);
     })
     .then(() => {
       return nightmare
@@ -378,10 +378,7 @@ module.exports.clickApp = (nightmare, done, app, pause) => {
     .wait(`#${app}-module-display`)
     .exists('#app-list-dropdown-toggle[aria-expanded="true"]')
     .then(dropdownOpen => {
-      if (dropdownOpen) nightmare.click('#app-list-dropdown-toggle');
-    })
-    .then(() => {
-      nightmare.wait('#app-list-dropdown-toggle[aria-expanded="false"]');
+      return dropdownOpen ? nightmare.click('#app-list-dropdown-toggle').wait('#app-list-dropdown-toggle[aria-expanded="false"]') : nightmare.wait(0);
     })
     .then(done)
     .catch(done);
@@ -403,7 +400,7 @@ module.exports.clickSettings = (nightmare, done, pause) => {
     .click('#app-list-item-clickable-settings')
     .exists('#app-list-dropdown-toggle[aria-expanded="true"]')
     .then(dropdownOpen => {
-      if (dropdownOpen) nightmare.click('#app-list-dropdown-toggle');
+      return dropdownOpen ? nightmare.click('#app-list-dropdown-toggle').wait('#app-list-dropdown-toggle[aria-expanded="false"]') : nightmare.wait(0);
     })
     .then(done)
     .catch(done);

--- a/helpers.js
+++ b/helpers.js
@@ -401,7 +401,7 @@ module.exports.clickApp = (nightmare, done, app, pause) => {
       if (dropdownOpen) {
         return nightmare
           .click('#app-list-dropdown-toggle')
-          .wait('#app-list-dropdown-toggle[aria-expanded="false"]') 
+          .wait('#app-list-dropdown-toggle[aria-expanded="false"]');
       }
       return nightmare.wait(0);
     })


### PR DESCRIPTION
I have an open PR in stripes-core ([STCOR-377](https://github.com/folio-org/stripes-core/pull/719)) with updates that changes how the main nav items are rendered, which has an effect on the existing integration tests.

In this PR I have made some changes for the test helpers to ensure that tests won't break once the updated MainNav is merged.

**Note:** I have tried to make this change backward compatible so that it will work with both the current stripes-core master and the new changes. 

It's tested and working in `ui-users` but we'll need to run all integration tests to ensure that everything is working as expected.

It's also assumed that all modules are using the updated test helpers to navigate between apps. If there should be some modules out there that are using their own custom solution for this purpose, then these modules would have to be updated individually.