### PR TITLE
UITEST-71 open closed accordions to find their buttons

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -120,6 +120,7 @@ module.exports.createInventory = (nightmare, config, title) => {
 module.exports.createNInventory = (nightmare, config, title, itemCount = 1) => {
   const barcodes = [];
   const ti = title || 'New test title';
+  const expandedAccordionSelector = (expanded) => `section[class^=accordion] button[type=button][aria-expanded=${expanded ? 'true' : 'false'}]`;
 
   it('should create instance record', (done) => {
     nightmare
@@ -155,10 +156,11 @@ module.exports.createNInventory = (nightmare, config, title, itemCount = 1) => {
       .wait('#clickable-create-holdings-record')
       .click('#clickable-create-holdings-record')
       .wait(() => !document.querySelector('#clickable-create-holdings-record'))
-      .wait('#clickable-new-item')
+      .wait(expandedAccordionSelector(false))
       .then(done)
       .catch(done);
   });
+
 
   /**
    * There is quite a lot of interaction with non-required fields in the
@@ -192,97 +194,108 @@ module.exports.createNInventory = (nightmare, config, title, itemCount = 1) => {
 
     it(`should create item record with barcode '${barcode}'`, (done) => {
       nightmare
-        .wait('#clickable-new-item')
-        .click('#clickable-new-item')
-        // Even though we wait for the #additem_barcode field to appear before
-        // interacting with it, that's not enough. With only that precaution in
-        // place, the first few characters of the barcode will occassionally be
-        // lost, i.e given a value of 123456789, only 3456789 will be captured.
-        // Adding a numeric timeout should be completely pointless given that we
-        // have the selector-timeout, but it ain't. Go figure.
-        .wait(1000)
-        .wait('#additem_barcode')
-        // Why, why `type` instead of `insert`? Why `type` in this, THE MOST
-        // UNRELIABLE of tests? Because `insert` fails consistently, that's
-        // why. Fails how? Like this: nothing happens, that's how. What do I
-        // mean, "nothing"? NOTHING. NOTHING HAPPENS. You can log things with
-        //    DEBUG=nightmare:actions*
-        // to your pretty little heart's content and see the `insert` command
-        // passes just fine, but if you watch carefully, about 20% of the time,
-        // the barcode field will be empty afterward and then the item-id and
-        // accession-number fields will populate with the same data, making
-        // clear that the value is available but for some reason Nightmare
-        // just didn't feel like using it.
-        //
-        // Am I bitter about this? Naw, I'm not bitter. Do I sound bitter?
-        // I don't think I sound bitter. I THINK I SOUND KINDA PISSED OFF
-        // because, you know what, I'm kinda pissed off.
-        .type('#additem_barcode', barcode)
-        // interaction with fields with on-blur handlers, like barcode,
-        // MUST be followed by interaction with other fields in order to
-        // trigger the blur event. some delay is necessary as well in
-        // order to allow the event to trigger and complete.
-        .wait(200)
-        .wait('#additem_itemidentifier')
-        .insert('#additem_itemidentifier', `iid-${barcode}`)
-        .wait('#additem_materialType')
-        .wait('#additem_loanTypePerm')
-        .evaluate(() => {
-          const node = Array.from(
-            document.querySelectorAll('#additem_materialType option')
-          ).find(e => e.text.startsWith('b'));
-          if (node) {
-            return node.value;
-          } else {
-            throw new Error('Could not find the ID for the materialType b...');
+        .exists(expandedAccordionSelector(false))
+        .then(isClosed => {
+          if (isClosed) {
+            nightmare
+              .click(expandedAccordionSelector(false))
+              .wait(expandedAccordionSelector(true));
           }
         })
-        .then((mtypeid) => {
-          return nightmare
-            .wait(`#additem_materialType option[value="${mtypeid}"]`)
-            .select('#additem_materialType', mtypeid)
-            // it is IMPERATIVE that interaction with a non-select component
-            // immediately follows select(). See UIIN-671 for details.
-            .wait('#additem_numberofpieces')
-            .insert('#additem_numberofpieces', 1)
+        .then(() => {
+          nightmare
+            .wait('#clickable-new-item')
+            .click('#clickable-new-item')
+            // Even though we wait for the #additem_barcode field to appear before
+            // interacting with it, that's not enough. With only that precaution in
+            // place, the first few characters of the barcode will occassionally be
+            // lost, i.e given a value of 123456789, only 3456789 will be captured.
+            // Adding a numeric timeout should be completely pointless given that we
+            // have the selector-timeout, but it ain't. Go figure.
+            .wait(1000)
+            .wait('#additem_barcode')
+            // Why, why `type` instead of `insert`? Why `type` in this, THE MOST
+            // UNRELIABLE of tests? Because `insert` fails consistently, that's
+            // why. Fails how? Like this: nothing happens, that's how. What do I
+            // mean, "nothing"? NOTHING. NOTHING HAPPENS. You can log things with
+            //    DEBUG=nightmare:actions*
+            // to your pretty little heart's content and see the `insert` command
+            // passes just fine, but if you watch carefully, about 20% of the time,
+            // the barcode field will be empty afterward and then the item-id and
+            // accession-number fields will populate with the same data, making
+            // clear that the value is available but for some reason Nightmare
+            // just didn't feel like using it.
+            //
+            // Am I bitter about this? Naw, I'm not bitter. Do I sound bitter?
+            // I don't think I sound bitter. I THINK I SOUND KINDA PISSED OFF
+            // because, you know what, I'm kinda pissed off.
+            .type('#additem_barcode', barcode)
+            // interaction with fields with on-blur handlers, like barcode,
+            // MUST be followed by interaction with other fields in order to
+            // trigger the blur event. some delay is necessary as well in
+            // order to allow the event to trigger and complete.
+            .wait(200)
+            .wait('#additem_itemidentifier')
+            .insert('#additem_itemidentifier', `iid-${barcode}`)
+            .wait('#additem_materialType')
+            .wait('#additem_loanTypePerm')
             .evaluate(() => {
               const node = Array.from(
-                document.querySelectorAll('#additem_loanTypePerm option')
-              ).find(e => e.text.startsWith('C'));
+                document.querySelectorAll('#additem_materialType option')
+              ).find(e => e.text.startsWith('b'));
               if (node) {
                 return node.value;
               } else {
-                throw new Error('Could not find the ID for the loanTypePerm C...');
+                throw new Error('Could not find the ID for the materialType b...');
               }
-            });
-        })
-        .then((ltypeid) => {
-          nightmare
-            .wait(`#additem_loanTypePerm option[value="${ltypeid}"]`)
-            .wait(200)
-            .select('#additem_loanTypePerm', ltypeid)
-            // it is IMPERATIVE that interaction with a non-select component
-            // immediately follows select(). See UIIN-671 for details.
-            .wait('#additem_accessionnumber')
-            .insert('#additem_accessionnumber', `an-${barcode}`)
-            // click other things, because without these clicks,
-            // the submit-button click never registers.
-            .wait('#clickable-add-former-id')
-            .click('#clickable-add-former-id')
-            .wait('#clickable-add-statistical-code')
-            .click('#clickable-add-statistical-code')
-            .wait('#clickable-create-item')
-            .click('#clickable-create-item')
-            .wait(() => !document.querySelector('#clickable-create-item'))
-            .wait('#list-items')
-            .wait(bc => {
-              return !!(Array.from(document.querySelectorAll('#list-items [role=gridcell]'))
-                .find(e => `${bc}` === e.textContent)); // `${}` forces string interpolation for numeric barcodes
-            }, barcode)
-            .then(done)
+            })
+            .then((mtypeid) => {
+              return nightmare
+                .wait(`#additem_materialType option[value="${mtypeid}"]`)
+                .select('#additem_materialType', mtypeid)
+                // it is IMPERATIVE that interaction with a non-select component
+                // immediately follows select(). See UIIN-671 for details.
+                .wait('#additem_numberofpieces')
+                .insert('#additem_numberofpieces', 1)
+                .evaluate(() => {
+                  const node = Array.from(
+                    document.querySelectorAll('#additem_loanTypePerm option')
+                  ).find(e => e.text.startsWith('C'));
+                  if (node) {
+                    return node.value;
+                  } else {
+                    throw new Error('Could not find the ID for the loanTypePerm C...');
+                  }
+                });
+            })
+            .then((ltypeid) => {
+              nightmare
+                .wait(`#additem_loanTypePerm option[value="${ltypeid}"]`)
+                .wait(200)
+                .select('#additem_loanTypePerm', ltypeid)
+                // it is IMPERATIVE that interaction with a non-select component
+                // immediately follows select(). See UIIN-671 for details.
+                .wait('#additem_accessionnumber')
+                .insert('#additem_accessionnumber', `an-${barcode}`)
+                // click other things, because without these clicks,
+                // the submit-button click never registers.
+                .wait('#clickable-add-former-id')
+                .click('#clickable-add-former-id')
+                .wait('#clickable-add-statistical-code')
+                .click('#clickable-add-statistical-code')
+                .wait('#clickable-create-item')
+                .click('#clickable-create-item')
+                .wait(() => !document.querySelector('#clickable-create-item'))
+                .wait('#list-items')
+                .wait(bc => {
+                  return !!(Array.from(document.querySelectorAll('#list-items [role=gridcell]'))
+                    .find(e => `${bc}` === e.textContent)); // `${}` forces string interpolation for numeric barcodes
+                }, barcode)
+                .then(done)
+                .catch(done);
+            })
             .catch(done);
-        })
-        .catch(done);
+        });
     });
   }
 


### PR DESCRIPTION
Let us go then, you and I
When my Nightmare is spread out against the sky
Like an Interactor etherized upon a table.
Let us paw through certain half-functional tests
And CSS resets
For buttons lost in holdings' empty well.
Click new-item button pearls in accordion-shells.

Refs [UITEST-71](https://issues.folio.org/browse/UITEST-71)