### PR TITLE
UITEST-74 click the correct accordion

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -120,7 +120,7 @@ module.exports.createInventory = (nightmare, config, title) => {
 module.exports.createNInventory = (nightmare, config, title, itemCount = 1) => {
   const barcodes = [];
   const ti = title || 'New test title';
-  const expandedAccordionSelector = (expanded) => `section[class^=accordion] button[type=button][aria-expanded=${expanded ? 'true' : 'false'}]`;
+  const expandedAccordionSelector = (expanded) => `section[class^=pane]:nth-of-type(3) section[class^=accordion] button[type=button][aria-expanded=${expanded ? 'true' : 'false'}]`;
 
   it('should create instance record', (done) => {
     nightmare


### PR DESCRIPTION
The selector for clicking the holdings-record's accordion was not
sufficiently selective, finding the first accordion in any pane rather
than specifically in the instance-details pane. In tests, the effect was
that the click was directed to an accordion in the search pane rather
than in the details pane.

I'm not sure why this manifested now. It's possible some recent work on
accordions in stripes-components is related, e.g.
https://github.com/folio-org/stripes-components/pull/1191, but isn't
clear how that would be the case.

Refs [UITEST-74](https://issues.folio.org/browse/UITEST-74)