### PR TITLE
refactor checkoutList

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -651,11 +651,15 @@ module.exports.checkout = (nightmare, done, itemBarcode, userBarcode) => {
 /**
  * checkout multiple items to a given user
  *
+ * NOTE: this function DOES NOT CALL done(); rather, it returns the
+ * nightmare instance it received so the calling function can do that in
+ * its own then() block.
+ *
  * @itemBarcodeList string[] an array of barcodes
  * @userBarcode string a user barcode
  */
-module.exports.checkoutList = (nightmare, done, itemBarcodeList, userBarcode) => {
-  nightmare
+module.exports.checkoutList = (nightmare, itemBarcodeList, userBarcode) => {
+  return nightmare
     .wait('#input-patron-identifier')
     .insert('#input-patron-identifier', userBarcode)
     .wait('#clickable-find-patron')
@@ -681,9 +685,7 @@ module.exports.checkoutList = (nightmare, done, itemBarcodeList, userBarcode) =>
               .find(e => `${bc}` === e.textContent)); // `${}` forces string interpolation for numeric barcodes
           }, itemBarcode);
       });
-    })
-    .then(done)
-    .catch(done);
+    });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-testing",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Regression tests for FOLIO UI",
   "repository": "folio-org/stripes-testing",
   "publishConfig": {


### PR DESCRIPTION
Don't accept `done` or call it within `checkoutList`. Instead, return
the given `nightmare` instance in order to wait until all the promises
in the `then` block here resolve, allowing the calling function to call
`done` in its own `then` block.