### PR TITLE
STCOM-785: Button interactor

### DIFF
--- a/interactors/button.js
+++ b/interactors/button.js
@@ -1,0 +1,18 @@
+import { Button as ButtonInteractor, createInteractor, perform, focused, isVisible } from '@bigtest/interactor';
+
+export default createInteractor('button')({
+  selector: ['a[href]', ButtonInteractor().specification.selector].join(','),
+  filters: {
+    id: (el) => el.id,
+    text: (el) => el.textContent,
+    href: (el) => el.getAttribute('href'),
+    button: (el) => el.tagName === 'BUTTON',
+    anchor: (el) => el.tagName === 'A',
+    default: (el) => el.classList.contains('default'),
+    visible: { apply: isVisible, default: true },
+    focused,
+  },
+  actions: {
+    click: perform((el) => el.click()),
+  }
+});

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -4,3 +4,4 @@ export { Tooltip, TooltipProximity } from './tooltip';
 export { default as converge } from './converge';
 export { default as Select } from './select';
 export { default as Label } from './label';
+export { default as Button } from './button';


### PR DESCRIPTION
## Motivation

Upgrade the Buttton interactor to the new bigtest interactor syntax and make it available for consumption by any test suite. You can see this in action in folio-org/stripes-components#1459

## Approach

The button can render either as a button tag or as a link, therefore extending the button interactor from bigtest did not feel like the best approach. Instead this uses a custom interactor.