### PR TITLE
STCOM-785 ✨New tooltip interactor

### DIFF
--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -36,6 +36,7 @@ include the DOM under test such as Selenium, or Nightmare.
 ### Table of Contents
 
 - [`Accordion`](#accordion)
+- [`Tooltip`](#tooltip)
 
 #### Accordion
 
@@ -75,4 +76,38 @@ Accordion("Categories").exists()
   inside this accordion
 - `index`: _number_ = the 0 based index of this accordion with in a
   pane set. So for example `Accordion("Users").has({ index: 2 })`
-  would assert that the "Users" accordion was 3rd in its accordion set.
+  would assert that the "Users" accordion was 3rd in its accordion
+  set.
+
+#### Tooltip
+
+Informational text that appears next to an element on mouseover in
+order to provide additional instructions
+
+##### Synopsis
+
+``` javascript
+import { Tooltip } from '@folio/stripes-testing';
+
+Tooltip("Throw this user to the trash").exists();
+```
+
+##### Locator
+
+Tooltips are located by their text property:
+
+```javascript
+Tooltip("save this document").has({ text: "save this document" });
+```
+
+### Filters
+
+- `id`: _string_ = the DOM element id of this tooltip. The `id` filter
+  is providerd for debugging, but should not generally be used for
+  tests
+- `text`: _string_ = the text of the toolip
+- `subtext`: _string_ = subtext of the tooltip
+- `visible`: _boolean_ = `true` if the tooltip is currently showing
+- `proximity`: _boolean_ = `true` if this tooltip is a proximity
+  tooltip in the DOM for the benefit of assitive technology. You
+  should not generally need to use this filter in tests

--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -8,7 +8,8 @@ export default createInteractor('keyboard')({
     arrowUp: press('ArrowUp'),
     arrowDown: press('ArrowDown'),
     home: press('Home'),
-    end: press('End')
+    end: press('End'),
+    escape: press('Escape')
   }
 })();
 
@@ -17,7 +18,8 @@ const KEY_CODES = {
   ArrowDown: 40,
   ArrowUp: 38,
   Home: 36,
-  End: 35
+  End: 35,
+  Escape: 27,
 };
 
 

--- a/interactors/tooltip.js
+++ b/interactors/tooltip.js
@@ -2,7 +2,7 @@ import { createInteractor, perform } from '@bigtest/interactor';
 import { isVisible } from 'element-is-visible';
 
 export const Tooltip = createInteractor('tooltip')({
-  selector: '[class^=tooltip], .sr-only',
+  selector: '[class^=tooltip], [data-test-tooltip-proximity-element]',
   locator: (el) => {
     return el.querySelector('[class^=text], span[role=tooltip]').textContent;
   },
@@ -12,9 +12,7 @@ export const Tooltip = createInteractor('tooltip')({
     visible: isVisible,
     id: (el) => el.id,
     proximity: {
-      apply: (el) => {
-        return el.querySelector('span[role=tooltip]').getAttribute('role') === 'tooltip';
-      },
+      apply: (el) => el.getAttribute('data-test-tooltip-proximity-element') === 'true',
       default: false,
     }
   },

--- a/interactors/tooltip.js
+++ b/interactors/tooltip.js
@@ -7,22 +7,14 @@ export const Tooltip = createInteractor('tooltip')({
     return el.querySelector('[class^=text], span[role=tooltip]').textContent;
   },
   filters: {
-    text: (el) => el.querySelector('[class^=text]').textContent,
-    sub: (el) => el.querySelector('[class^=sub]').textContent,
-    visible: isVisible,
     id: (el) => el.id,
+    text: (el) => el.querySelector('[class^=text]').textContent,
+    subtext: (el) => el.querySelector('[class^=sub]').textContent,
+    visible: isVisible,
     proximity: {
       apply: (el) => el.getAttribute('data-test-tooltip-proximity-element') === 'true',
       default: false,
     }
-  },
-  actions: {
-    pressEscape: perform((el) => {
-      const kbEvent = new KeyboardEvent('keydown', {
-        key: 'Escape'
-      });
-      return el.dispatchEvent(kbEvent);
-    })
   }
 });
 

--- a/interactors/tooltip.js
+++ b/interactors/tooltip.js
@@ -1,4 +1,4 @@
-import { createInteractor, perform } from '@bigtest/interactor';
+import { createInteractor } from '@bigtest/interactor';
 import { isVisible } from 'element-is-visible';
 
 export const Tooltip = createInteractor('tooltip')({


### PR DESCRIPTION
This fixes the tooltip interactor which was in-flight. The main thing that I did was to continue to rely on the `data-test-proximity-tooltip-element` attribute for the interactor which seemed very reasonable given that there is very little else to identify that element.... So you would use it like:

```javascript
await Tooltip("save document").is({ visible: true });
await Tooltip("save document, { proximity: true }).exists();
```

It's unlikely that anybody would use the proximity filter in anything but the stripes-components test suite.