### PR TITLE
FOLIO-2923: Drop --no-check-certificate from wget (MitM attack)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ ARG folio_registry=https://repository.folio.org/repository/npm-folioci/
 RUN apt-get -q update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -q install -y \
     -o Dpkg::Options::="--force-confnew"  --no-install-recommends \
-    git wget unzip bzip2 xvfb && \
+    git ca-certificates wget unzip bzip2 xvfb && \
     apt-get install -y libgtk2.0-0 libxtst6 libxss1 libgconf-2-4 libnss3 libnspr4  libasound2 && \
     apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && \
     rm -f /var/cache/apt/*.bin
 
 ENV NODEJS_VERSION 8
 
-RUN wget --no-check-certificate --no-cookies https://deb.nodesource.com/setup_${NODEJS_VERSION}.x -O /tmp/node.sh  && \
+RUN wget --no-cookies https://deb.nodesource.com/setup_${NODEJS_VERSION}.x -O /tmp/node.sh  && \
     chmod +x /tmp/node.sh && \
     sh -c "/tmp/node.sh" && \
     rm -f /tmp/node.sh && \


### PR DESCRIPTION
`wget --no-check-certificate` disables certificate checks and makes the
installation vulnerable to Man-in-the-middle attacks that might install
malware.

No longer use `--no-check-certificate`.
Make sure that the package ca-certificates is installed. wget needs it
to check certificates.