### PR TITLE
STCOM-785: interactors update: text-field

### DIFF
--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -181,6 +181,11 @@ TextField("First Name").has({ label: "First Name" });
 - `readOnly`: _boolean_ = `true` if the text field is read-only
 - `startControl`: _string_ = the text content of the `startControl` element
 - `endControl`: _string_ = the text content of the `endControl` element
+- `error`: _string_ = text of the error associated with this
+  text field. If there is no error, then this will be undefined
+- `warning`: _string_ = text of the warning associated with this
+  text field. If there is no warning, then this will be undefined
+- `valid`: _boolean_ = is this text field valid?
 
 ##### Actions
 - `blur()`: removes focus from the text field

--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -36,9 +36,10 @@ include the DOM under test such as Selenium, or Nightmare.
 ### Table of Contents
 
 - [`Accordion`](#accordion)
-- [`Pane`](#tooltip)
+- [`Pane`](#pane)
 - [`KeyValue`](#keyvalue)
 - [`Select`](#select)
+- [`TextField`](#textfield)
 - [`Tooltip`](#tooltip)
 
 #### Accordion
@@ -148,6 +149,44 @@ Pane("Search Result").exists();
 - `index`: _number_ = the 0 based index of this pane with in a
   pane set. So for example `Pane("Users").has({ index: 2 })`
   would assert that the "Users" pane was 3rd in its pane set.
+
+#### TextField
+
+Stripes TextField component wraps a standard `input` text element, adding support for things like controls and error states.
+
+##### Synopsis
+
+``` javascript
+import { TextField } from '@folio/stripes-testing';
+
+TextField("First Name").exists();
+```
+
+##### Locator
+
+Text fields are located by their label:
+
+```javascript
+TextField("First Name").has({ label: "First Name" });
+```
+
+##### Filters
+- `id`: _string_ = the DOM element id of this text field. The `id` filter
+  is providerd for debugging, but should not generally be used for
+  tests
+- `label`: _string_ = the label of the text field
+- `type`: _string_ = the type of the text field. should always return `"text"`
+- `value`: _string_ = the current value of the text field
+- `focused`: _boolean_ = `true` if the text field is currently in focus
+- `readOnly`: _boolean_ = `true` if the text field is read-only
+- `startControl`: _string_ = the text content of the `startControl` element
+- `endControl`: _string_ = the text content of the `endControl` element
+
+##### Actions
+- `blur()`: removes focus from the text field
+- `clear()`: clears the text field's current value
+- `fillIn(value: string)`: fills in the text field with a given value
+- `focus()`: sets focus on the text field
 
 #### Tooltip
 

--- a/interactors/icon-button.js
+++ b/interactors/icon-button.js
@@ -10,6 +10,7 @@ export default createInteractor('icon button')({
     id: (el) => el.id,
     href: (el) => el.getAttribute('href'),
     hash: (el) => el.hash,
+    icon: (el) => el.getAttribute('icon'),
   },
   actions: {
     focus: perform((el) => el.focus()),

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -10,5 +10,4 @@ export { default as Select } from './select';
 export { default as Label } from './label';
 export { default as Button } from './button';
 export { default as Pane } from './pane';
-
-export { TextField } from '@bigtest/interactor';
+export { default as TextField } from './text-field';

--- a/interactors/text-field.js
+++ b/interactors/text-field.js
@@ -1,0 +1,32 @@
+import { createInteractor, perform, TextField } from '@bigtest/interactor';
+
+import IconButton from './icon-button';
+
+const label = (el) => {
+  const labelText = el.querySelector('label');
+  return labelText ? labelText.innerText : undefined;
+};
+
+export default createInteractor('text field')({
+  selector: 'div[class^=textField-]',
+  locator: label,
+  filters: {
+    id: (el) => el.querySelector('input').id,
+    label,
+    type: (el) => el.querySelector('input').type,
+    value: (el) => el.querySelector('input').value,
+    focused: (el) => el.querySelector('input').contains(el.ownerDocument.activeElement),
+    readOnly: (el) => el.querySelector('input').hasAttribute('readOnly'),
+    startControl: (el) => el.querySelector('[class^=startControls').textContent,
+    endControl: (el) => el.querySelector('[class^=endControls').textContent,
+  },
+  actions: {
+    blur: perform((el) => el.querySelector('input').blur()),
+    clear: async (interactor) => {
+      await interactor.focus();
+      await interactor.find(IconButton({ icon: 'times-circle-solid' })).click();
+    },
+    fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),
+    focus: perform((el) => el.querySelector('input').focus()),
+  }
+});

--- a/interactors/text-field.js
+++ b/interactors/text-field.js
@@ -19,6 +19,9 @@ export default createInteractor('text field')({
     readOnly: (el) => el.querySelector('input').hasAttribute('readOnly'),
     startControl: (el) => el.querySelector('[class^=startControls').textContent,
     endControl: (el) => el.querySelector('[class^=endControls').textContent,
+    error: (el) => (el.querySelector('[class*=feedbackError-]') || {}).textContent,
+    warning: (el) => (el.querySelector('[class*=feedbackWarning-]') || {}).textContent,
+    valid: el => el.querySelector('input').getAttribute('aria-invalid') !== 'true'
   },
   actions: {
     blur: perform((el) => el.querySelector('input').blur()),


### PR DESCRIPTION
## Motivation
Upgrade the `TextField` interactor to the new bigtest interactor syntax, and make it available for consumption by the test suite.

## Approach
Added a `TextField` interactor, with filters and actions that cover the common ways of interacting with a text field.

See this in action here: https://github.com/folio-org/stripes-components/pull/1468