### PR TITLE
STCOM-785: interactors update: textarea

### DIFF
--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -45,6 +45,7 @@ include the DOM under test such as Selenium, or Nightmare.
 - [`Pane`](#pane)
 - [`RadioButton`](#radiobutton)
 - [`Select`](#select)
+- [`TextArea`](#textarea)
 - [`TextField`](#textfield)
 - [`Tooltip`](#tooltip)
 
@@ -434,6 +435,46 @@ Select("Country").exists();
 - `warning`: _string_ = text of the warning associated with this
   select. If there is no warning, then this will be undefined
 - `valid`: _boolean_ = is this select valid?
+
+
+#### TextArea
+
+Stripes TextArea component wraps a standard `textarea` element,
+adding support for things like controls and error states.
+
+##### Synopsis
+
+``` javascript
+import { TextArea } from '@folio/stripes-testing';
+
+TextArea("leave a comment").exists();
+```
+
+##### Locator
+
+A TextArea is located by its label property:
+
+```javascript
+TextArea("leave a comment").has({ text: "leave a comment" });
+```
+
+##### Filters
+- `id`: _string_ = the DOM element id of this textarea. The `id` filter
+  is providerd for debugging, but should not generally be used for
+  tests
+- `label`: _string_ = the label of the textarea
+- `value`: _string_ = the current value of the textarea
+- `error`: _string_ = text of the error associated with this
+  textarea. If there is no error, then this will be undefined
+- `warning`: _string_ = text of the warning associated with this
+  textarea. If there is no warning, then this will be undefined
+- `valid`: _boolean_ = is this textarea valid?
+
+##### Actions
+- `blur()`: removes focus from the textarea
+- `fillIn(value: string)`: fills in the textarea with a given value
+- `focus()`: sets focus on the textarea
+
 
 #### TextField
 

--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -460,7 +460,7 @@ TextArea("leave a comment").has({ text: "leave a comment" });
 
 ##### Filters
 - `id`: _string_ = the DOM element id of this textarea. The `id` filter
-  is providerd for debugging, but should not generally be used for
+  is provided for debugging, but should not generally be used for
   tests
 - `label`: _string_ = the label of the textarea
 - `value`: _string_ = the current value of the textarea

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -14,3 +14,4 @@ export { default as Button } from './button';
 export { default as Pane } from './pane';
 export { default as TextField } from './text-field';
 export { default as Dropdown } from './dropdown';
+export { default as TextArea } from './textarea';

--- a/interactors/textarea.js
+++ b/interactors/textarea.js
@@ -1,0 +1,27 @@
+import { createInteractor, perform } from '@bigtest/interactor';
+
+const label = (el) => {
+  const labelText = el.querySelector('label');
+  return labelText ? labelText.innerText : undefined;
+};
+
+export default createInteractor('text area')({
+  selector: 'div[class^=textArea-]',
+  locator: label,
+  filters: {
+    id: el => el.querySelector('textarea').getAttribute('id'),
+    label,
+    value: el => el.querySelector('textarea').value,
+    warning: el => el.querySelector('[class^=feedbackWarning-]').textContent,
+    error: el => el.querySelector('[class^=feedbackError-]').textContent,
+    valid: el => el.querySelector('textarea').getAttribute('aria-invalid') !== 'true'
+  },
+  actions: {
+    blur: perform(el => el.querySelector('textarea').blur()),
+    fillIn: async (interactor, value) => {
+      await interactor.focus();
+      await interactor.perform(el => { el.querySelector('textarea').value = value; });
+    },
+    focus: perform(el => el.querySelector('textarea').focus()),
+  }
+});

--- a/interactors/textarea.js
+++ b/interactors/textarea.js
@@ -1,4 +1,4 @@
-import { createInteractor, perform } from '@bigtest/interactor';
+import { createInteractor, TextField } from '@bigtest/interactor';
 
 const label = (el) => {
   const labelText = el.querySelector('label');
@@ -17,11 +17,8 @@ export default createInteractor('text area')({
     valid: el => el.querySelector('textarea').getAttribute('aria-invalid') !== 'true'
   },
   actions: {
-    blur: perform(el => el.querySelector('textarea').blur()),
-    fillIn: async (interactor, value) => {
-      await interactor.focus();
-      await interactor.perform(el => { el.querySelector('textarea').value = value; });
-    },
-    focus: perform(el => el.querySelector('textarea').focus()),
+    blur: (interactor) => interactor.find(TextField()).blur(),
+    fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),
+    focus: (interactor) => interactor.find(TextField()).focus(),
   }
 });


### PR DESCRIPTION
## Motivation
Upgrade the `TextArea` interactor to the new bigtest interactor syntax, and make it available for consumption by the test suite.

## Approach
Added a `TextArea` interactor, with filters and actions that cover the common ways of interacting with a text field.

See this in action here: https://github.com/folio-org/stripes-components/pull/1470