### PR TITLE
STCOM-785: interactors update: searchField

### DIFF
--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -298,7 +298,13 @@ import { SearchField } from '@folio/stripes-testing';
 
 SearchField().has({ id: 'searchFieldTest'});
 ```
+##### Locator
 
+A SearchField is located by ___. For example:
+
+```javascript
+SearchField("Label").exists();
+```
 ##### Actions
 
 - `selectIndex(string)`: selects the searchable index to perform this search on. For example "users" or "locations"

--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -41,6 +41,7 @@ include the DOM under test such as Selenium, or Nightmare.
 - [`Layer`](#layer)
 - [`Pane`](#pane)
 - [`RadioButton`](#radiobutton)
+- [`SearchField`](#searchField)
 - [`Select`](#select)
 - [`TextField`](#textfield)
 - [`Tooltip`](#tooltip)
@@ -285,6 +286,35 @@ RadioButton("Label").exists();
 - `feedbackText`: _string_ = the text related to the validation warning or error
 - `hasWarning`: _boolean_ = `true` if the radio button has a warning [class]
 - `hasError`: _boolean_ = `true` if the radio button has an error [class]
+
+#### SearchField
+
+Stripes SearchField component composes basic `<select>` and `<input>` elements
+
+##### Synopsis
+
+``` javascript
+import { SearchField } from '@folio/stripes-testing';
+
+SearchField().has({ id: 'searchFieldTest'});
+```
+
+##### Actions
+
+- `selectIndex(string)`: selects the option matching option name
+- `fillIn(value: string)`: fills in the text field with a given value
+
+##### Filters
+
+- `id`: _string_ = the DOM element id of the contained `select`
+  element.  Note that this _not the id of the React component_. The `id`
+  filter is provided for debugging, but should not generally be used
+  in tests since it is not a user-facing value.
+- `placeholder`: _string_ = The placeholder text of the contained `input` element.
+- `value`: _string_ = the `value` property of the contained `input` element.
+- `readOnly`: _boolean_ = `true` if the contained `input` is read-only.
+- `isDisabledIndex`: _boolean_ = `true` if the contained `select` is disabled.
+- `isDisabled`: _boolean_ = `true` if the contained `input` is disabled.
 
 #### Select
 

--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -319,7 +319,7 @@ SearchField("Label").exists();
 - `placeholder`: _string_ = The placeholder text of the contained `input` element.
 - `value`: _string_ = the `value` property of the contained `input` element.
 - `readOnly`: _boolean_ = `true` if the contained `input` is read-only.
-- `isDisabled`: _boolean_ = `true` if the contained `input` is disabled.
+- `disabled`: _boolean_ = `true` if the contained `input` is disabled.
 
 #### Select
 

--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -289,7 +289,7 @@ RadioButton("Label").exists();
 
 #### SearchField
 
-Stripes SearchField component composes basic `<select>` and `<input>` elements
+Stripes SearchField component for initiating queries
 
 ##### Synopsis
 
@@ -301,7 +301,7 @@ SearchField().has({ id: 'searchFieldTest'});
 
 ##### Actions
 
-- `selectIndex(string)`: selects the option matching option name
+- `selectIndex(string)`: selects the searchable index to perform this search on. For example "users" or "locations"
 - `fillIn(value: string)`: fills in the text field with a given value
 
 ##### Filters
@@ -313,7 +313,6 @@ SearchField().has({ id: 'searchFieldTest'});
 - `placeholder`: _string_ = The placeholder text of the contained `input` element.
 - `value`: _string_ = the `value` property of the contained `input` element.
 - `readOnly`: _boolean_ = `true` if the contained `input` is read-only.
-- `isDisabledIndex`: _boolean_ = `true` if the contained `select` is disabled.
 - `isDisabled`: _boolean_ = `true` if the contained `input` is disabled.
 
 #### Select

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -8,6 +8,7 @@ export { Tooltip, TooltipProximity } from './tooltip';
 export { default as Layer } from './layer';
 export { default as converge } from './converge';
 export { default as RadioButton } from './radio-button';
+export { default as SearchField } from './search-field';
 export { default as Select } from './select';
 export { default as Label } from './label';
 export { default as Button } from './button';

--- a/interactors/search-field.js
+++ b/interactors/search-field.js
@@ -1,0 +1,17 @@
+import { createInteractor, TextField, Select } from '@bigtest/interactor';
+
+export default createInteractor('search field')({
+  selector: '[class^=searchField]',
+  filters: {
+    id: el => el.querySelector('input').getAttribute('id'),
+    readOnly: el => el.querySelector('input').hasAttribute('readOnly'),
+    value: el => el.querySelector('input').value,
+    placeholder: el => el.querySelector('input').placeholder,
+    isDisabledIndex: el => el.querySelector('select').disabled,
+    isDisabled: el => el.querySelector('input').disabled,
+  },
+  actions: {
+    fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),
+    selectIndex: (interctor, value) => interctor.find(Select()).choose(value),
+  }
+});

--- a/interactors/search-field.js
+++ b/interactors/search-field.js
@@ -7,11 +7,10 @@ export default createInteractor('search field')({
     readOnly: el => el.querySelector('input').hasAttribute('readOnly'),
     value: el => el.querySelector('input').value,
     placeholder: el => el.querySelector('input').placeholder,
-    isDisabledIndex: el => el.querySelector('select').disabled,
-    isDisabled: el => el.querySelector('input').disabled,
+    isDisabled: el => el.querySelector('select').disabled,
   },
   actions: {
     fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),
-    selectIndex: (interctor, value) => interctor.find(Select()).choose(value),
+    selectIndex: (interactor, value) => interactor.find(Select()).choose(value),
   }
 });

--- a/interactors/search-field.js
+++ b/interactors/search-field.js
@@ -1,7 +1,13 @@
 import { createInteractor, TextField, Select } from '@bigtest/interactor';
 
+const label = (el) => {
+  const labelText = el.querySelector('label');
+  return labelText ? labelText.innerText : undefined;
+};
+
 export default createInteractor('search field')({
   selector: '[class^=searchField]',
+  locator: label,
   filters: {
     id: el => el.querySelector('input').getAttribute('id'),
     readOnly: el => el.querySelector('input').hasAttribute('readOnly'),

--- a/interactors/search-field.js
+++ b/interactors/search-field.js
@@ -13,7 +13,7 @@ export default createInteractor('search field')({
     readOnly: el => el.querySelector('input').hasAttribute('readOnly'),
     value: el => el.querySelector('input').value,
     placeholder: el => el.querySelector('input').placeholder,
-    isDisabled: el => el.querySelector('select').disabled,
+    disabled: el => el.querySelector('select').disabled,
   },
   actions: {
     fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),


### PR DESCRIPTION
### Motivation

Upgrade the `SearchField` interactor to the new bigtest interactor syntax. Make it available for usage in the test suite.

### Approach

Added a `SearchField` interactor, with filters and actions for interacting with a search-field.

See this in action here: