### PR TITLE
STCOM-785: interactors update: dropdown

### DIFF
--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -38,6 +38,7 @@ include the DOM under test such as Selenium, or Nightmare.
 - [`Accordion`](#accordion)
 - [`Button`](#button)
 - [`Checkbox`](#checkbox)
+- [`Dropdown`](#dropdown)
 - [`IconButton`](#iconbutton)
 - [`KeyValue`](#keyvalue)
 - [`Layer`](#layer)
@@ -172,6 +173,34 @@ Checkbox("Label").exists();
 - `feedbackText`: _string_ = the text related to the validation warning or error
 - `hasWarning`: _boolean_ = `true` if the checkbox has a warning [class]
 - `hasError`: _boolean_ = `true` if the checkbox has an error [class]
+
+#### Dropdown
+
+The Stripes Dropdown component
+
+##### Synopsis
+
+```javascript
+import { Dropdown } from "@folio/stripes-testing";
+
+Dropdown("Menu").choose("Contact Us");
+```
+
+Dropdowns are identified by their label, or trigger
+
+```javascript
+Dropdown("Menu").exists();
+```
+
+##### Actions
+
+- `choose(optionName: string)`: clicks a given option in the dropdown
+
+##### Filters
+- `open`: _boolean_ = `true` if the dropdown is open
+- `visible`: _boolean_ = `true` if the dropdown is visible
+- `label`: _string_ = the user identifying text of this
+  dropdown. This is the same value as the locator.
 
 #### IconButton
 

--- a/interactors/button.js
+++ b/interactors/button.js
@@ -11,7 +11,7 @@ export default createInteractor('button')({
     anchor: (el) => el.tagName === 'A',
     default: (el) => el.classList.contains('default'),
     ariaLabel: (el) => el.ariaLabel,
-    visible: { apply: isVisible, default: true },
+    visible: isVisible,
     focused,
   },
   actions: {

--- a/interactors/dropdown.js
+++ b/interactors/dropdown.js
@@ -16,19 +16,32 @@ const DropdownMenu = createInteractor('dropdown menu')({
   }
 });
 
+const open = el => el.querySelector('[aria-haspopup]').getAttribute('aria-expanded') === 'true';
+
+const control = (shouldOpen = true) => async interactor => {
+  let isOpen;
+  await interactor.perform(el => { isOpen = open(el); });
+  if (isOpen !== shouldOpen) {
+    await interactor.toggle();
+  }
+};
+
 export default createInteractor('dropdown')({
   selector: 'div[class*=dropdown]',
   locator: el => el.querySelector('[aria-haspopup]').textContent,
   filters: {
-    open: el => el.querySelector('[aria-haspopup]').getAttribute('aria-expanded') === 'true',
+    open,
     visible: el => [el, el.querySelector(['[aria-haspopup]'])].every(isVisible),
   },
   actions: {
     focus: interactor => interactor.find(DropdownTrigger()).focus(),
     toggle: interactor => interactor.find(DropdownTrigger()).click(),
+    open: control(true),
+    close: control(false),
     choose: async (interactor, value) => {
-      await interactor.find(DropdownTrigger()).click();
+      await interactor.open();
       await DropdownMenu({ visible: true }).find(ButtonInteractor(value)).click();
+      await interactor.close();
     },
   }
 });

--- a/interactors/dropdown.js
+++ b/interactors/dropdown.js
@@ -16,7 +16,13 @@ const DropdownMenu = createInteractor('dropdown menu')({
   }
 });
 
+const label = el => el.querySelector('[aria-haspopup]').textContent;
+
 const open = el => el.querySelector('[aria-haspopup]').getAttribute('aria-expanded') === 'true';
+
+// todo: 'visible' should ensure the DropdownMenu is visible as well,
+// once filters support interactor composition
+const visible = el => [el, el.querySelector(['[aria-haspopup]'])].every(isVisible);
 
 const control = (shouldOpen = true) => async interactor => {
   let isOpen;
@@ -28,11 +34,8 @@ const control = (shouldOpen = true) => async interactor => {
 
 export default createInteractor('dropdown')({
   selector: 'div[class*=dropdown]',
-  locator: el => el.querySelector('[aria-haspopup]').textContent,
-  filters: {
-    open,
-    visible: el => [el, el.querySelector(['[aria-haspopup]'])].every(isVisible),
-  },
+  locator: label,
+  filters: { label, open, visible },
   actions: {
     focus: interactor => interactor.find(DropdownTrigger()).focus(),
     toggle: interactor => interactor.find(DropdownTrigger()).click(),

--- a/interactors/dropdown.js
+++ b/interactors/dropdown.js
@@ -1,0 +1,34 @@
+import { createInteractor } from '@bigtest/interactor';
+import { isVisible } from 'element-is-visible';
+
+import ButtonInteractor from './button';
+
+const DropdownTrigger = createInteractor('dropdown trigger')({
+  selector: '[aria-haspopup]',
+  filters: ButtonInteractor().specification.filters,
+  actions: ButtonInteractor().specification.actions,
+});
+
+const DropdownMenu = createInteractor('dropdown menu')({
+  selector: 'div[class*=DropdownMenu]',
+  filters: {
+    visible: isVisible,
+  }
+});
+
+export default createInteractor('dropdown')({
+  selector: 'div[class*=dropdown]',
+  locator: el => el.querySelector('[aria-haspopup]').textContent,
+  filters: {
+    open: el => el.querySelector('[aria-haspopup]').getAttribute('aria-expanded') === 'true',
+    visible: el => [el, el.querySelector(['[aria-haspopup]'])].every(isVisible),
+  },
+  actions: {
+    focus: interactor => interactor.find(DropdownTrigger()).focus(),
+    toggle: interactor => interactor.find(DropdownTrigger()).click(),
+    choose: async (interactor, value) => {
+      await interactor.find(DropdownTrigger()).click();
+      await DropdownMenu({ visible: true }).find(ButtonInteractor(value)).click();
+    },
+  }
+});

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -13,3 +13,4 @@ export { default as Label } from './label';
 export { default as Button } from './button';
 export { default as Pane } from './pane';
 export { default as TextField } from './text-field';
+export { default as Dropdown } from './dropdown';


### PR DESCRIPTION
## Motivation
Upgrade the `Dropdown` interactor to the new bigtest interactor syntax, and make it available for consumption by the test suite.

## Approach
Added a `Dropdown` interactor, with filters and actions that cover the common ways of interacting with a text field.

See this in action here: https://github.com/folio-org/stripes-components/pull/1473