### PR TITLE
STCOM-785: interactors update: Datepicker

### DIFF
--- a/doc/interactors.md
+++ b/doc/interactors.md
@@ -87,6 +87,7 @@ and make a pull request to this package.
 - [`Button`](#button)
 - [`Checkbox`](#checkbox)
 - [`Dropdown`](#dropdown)
+- [`Datepicker`](#datepicker) ([`Calendar Widget`](#calendar-widget))
 - [`IconButton`](#iconbutton)
 - [`KeyValue`](#keyvalue)
 - [`Layer`](#layer)
@@ -225,6 +226,86 @@ Checkbox('Label').exists();
 - `feedbackText`: _string_ = the text related to the validation warning or error
 - `hasWarning`: _boolean_ = `true` if the checkbox has a warning [class]
 - `hasError`: _boolean_ = `true` if the checkbox has an error [class]
+#### Datepicker
+
+The datepicker and related elements
+
+##### Datepicker (input element)
+###### Synopsis
+
+```javascript
+import { Datepicker } from '@folio/stripes-testing';
+
+Datepicker().has({ today: true, required: true });
+```
+
+###### Locator
+
+Datepickers can be identified by their label. For example:
+
+```javascript
+Datepicker('Start Date').is({ visible: true });
+```
+
+###### Actions
+
+- `openCalendar`: clicks the icon that opens the calendar widget
+- `clear`: removes the value from the field
+- `click`: clicks the field
+- `focusInput`: focuses the input
+- `fillIn(value: string)`: fill in a specific date value as if the user typed in the field
+- `focus`: focuses the input field
+- `blur`: blurs the input field
+
+###### Filters
+
+- `id`: _string_ = the DOM element id of this datepciker. The `id` filter is provided for debugging, but should not generally be used in tests since it is not a user-facing value
+- `label`: _string_ = the user identifying text of this datepicker. This is the same value as the locator.
+- `placeholder`: _string_ = the input placeholder which is a user identifying text if label is not sufficiently unique.
+- `focused`: _boolean_ = `true` if the keyboard focus targets the input
+- `warning`: _boolean_ = `true` if in a warning state
+- `error`: _boolean_ = `true` if in an error state
+- `inputValue`: _string_ = the value in input
+- `inputDay`: _int_ = the day that is in the input
+- `today`: _boolean_ = `true` if the date in the input is today's date
+- `empty`: _boolean_ = `true` if the date in the input is cleared
+- `visible`: _boolean_ = `true` if the input is visible
+- `disabled`: _boolean_ = `true` if the input is disabled
+- `readOnly`: _boolean_ = `true` if the input is set to read only
+- `required`: _boolean_ = `true` if the input is a required field
+
+##### Calendar Widget
+###### Synopsis
+
+```javascript
+import { Calendar } from '@folio/stripes-testing';
+
+Calendar().is({ visible: true });
+```
+
+###### Locator
+
+The calendar widget does not have a locator. Only one widget may be visible at a time.
+
+###### Actions
+
+- `click`: clicks on the calendar widget container
+- `focus`: focuses on the calendar widget container
+- `clickDay(value: string)`: clicks the day passed on the calendar widget
+- `focusDay(value: string)`: focuses on a day passed within the calendar widget
+- `setYear(value: string)`: sets the year passed within the year input field in the widget
+
+###### Filters
+
+- `today`: _boolean_ = `true` if the input today's date
+- `month`: _string_ = the currently selected month
+- `year`: _string_ = the currently selected year
+- `days`: [_string_, _string_, ...] = an array of strings representing all of the days present (and not excluded) as two digits, `03` for the third day of the month. Note that days which are shown that are not within the currently selected month are surrounded by underscores, e.g. `_31_`, `_01_`
+- `excludedDays`: [_string_, _string_, ...] = the inverse of `days`, an array of strings representing all of the dates that are excluded
+- `portal`: _boolean_ = `true` if the widget is created within the `#OverlayContainer` portal
+- `visible`: _boolean_ = `true` if the input is visible
+- `focused`: _boolean_ = `true` if the calendar widget container is focused
+- `focusedWithin`: _boolean_ = `true` if anything within the widget has focus
 
 #### Dropdown
 

--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -1,0 +1,125 @@
+import { createInteractor, perform, focused, Select, TextField } from '@bigtest/interactor';
+import { isVisible } from 'element-is-visible';
+import { format, parseISO } from 'date-fns';
+import IconButton from './icon-button';
+
+export default createInteractor('datepicker')({
+  selector: '[data-test-datepicker-container]',
+  filters: {
+    id: (el) => el.querySelector('input').id,
+    inputValue: (el) => el.querySelector('div[class^=textField] input').value,
+    inputDay: (el) => Date(el.querySelector('div[class^=textField] input').value).getDay(),
+    placeholder: (el) => el.querySelector('div[class^=textField] input').placeholder,
+    label: (el) => el.querySelector('label').textContent,
+    warning: (el) => (
+      !el.querySelector('[role=alert] div')
+        ? false
+        : !!el.querySelector('[role=alert] div').className.match(/feedbackWarning/)
+    ),
+    error: (el) => (
+      !el.querySelector('[role=alert] div')
+        ? false
+        : !!el.querySelector('[role=alert] div').className.match(/feedbackError/)),
+    focused: (el) => el.ownerDocument.activeElement === el.querySelector('input'),
+    today: (el) => el.querySelector('input').value === format(new Date(), el.querySelector('input').placeholder),
+    empty: (el) => el.querySelector('input').value === '',
+    visible: {
+      apply: (element) => isVisible(element) || (element.labels && Array.from(element.labels).some(isVisible)),
+      default: true
+    },
+    disabled: {
+      apply: (el) => el.querySelector('input').hasAttribute('disabled'),
+      default: false
+    },
+    readOnly: (el) => el.querySelector('input').hasAttribute('readonly'),
+    required: (el) => el.querySelector('input').hasAttribute('required'),
+  },
+  actions: {
+    openCalendar: (interactor) => interactor.find(IconButton({ icon: 'calendar' })).click(),
+    clear: (interactor) => interactor.find(IconButton({ icon: 'times-circle-solid' })).click(),
+    click: perform((el) => { el.click(); }),
+    focusInput: (interactor) => interactor.find(TextField()).focus(),
+    fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),
+    focus: (interactor) => interactor.find(TextField()).focus(),
+    blur: (interactor) => interactor.find(TextField()).blur(),
+  }
+});
+
+const CalendarDays = createInteractor('calendar days')({
+  selector: '[class^=calendar-] td',
+  locator: (el) => {
+    if (el.textContent.length === 1) {
+      return `0${el.textContent}`;
+    } else {
+      return el.textContent;
+    }
+  },
+  filters: {
+    selected: (el) => !!el.querySelector('div').className.match(/selected-/),
+    dateSelected: (el) => el.getAttribute('data-date'),
+    disabled: (el) => el.querySelector('div').hasAttribute('data-excluded'),
+    month: (el) => el.getAttribute('data-date').split('/')[0],
+    year: (el) => el.getAttribute('data-date').split('/')[2],
+    focused
+  },
+  actions: {
+    click: perform((el) => { el.click(); }),
+    focus: perform((el) => { el.focus(); }),
+  }
+});
+
+export const Calendar = createInteractor('calendar widget')({
+  selector: '[class^=calendar-]',
+  filters: {
+    portal: (el) => el.parentElement.parentElement.id === 'OverlayContainer',
+    visible: {
+      apply: (el) => isVisible(el) || (el.labels && Array.from(el.labels).some(isVisible)),
+      default: true
+    },
+    focusedWithin: (el) => el.ownerDocument.activeElement === el,
+    today: (el) => format(parseISO(el.querySelector('td[tabindex="0"]').getAttribute('data-day')), 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd'),
+    month: (el) => el.querySelector('select').selectedOptions[0].label || '',
+    year: (el) => el.querySelector('input').value,
+    days: (el) => Array.from(el.querySelectorAll('td')).reduce(
+      (days, node) => {
+        if (node.getAttribute('data-excluded') !== 'true') {
+          if (node.querySelector('[class*=muted-]')) {
+            return days.concat([`_${node.textContent}_`]);
+          } else {
+            return days.concat([node.textContent]);
+          }
+        } else {
+          return days;
+        }
+      }, []
+    ),
+    excludedDays: (el) => Array.from(el.querySelectorAll('td')).reduce(
+      (days, node) => {
+        if (node.getAttribute('data-excluded') === 'true') {
+          if (node.querySelector('[class*=muted-]')) {
+            return days.concat([`_${node.textContent}_`]);
+          } else {
+            return days.concat([node.textContent]);
+          }
+        } else {
+          return days;
+        }
+      }, []
+    ),
+    focused
+  },
+  actions: {
+    click: perform((el) => { el.click(); }),
+    focus: perform((el) => { el.focus(); }),
+    clickDay: (interactor, value) => interactor.find(CalendarDays(value)).click(),
+    focusDay: (interactor, value) => interactor.find(CalendarDays(value)).focus(),
+    setYear: (interactor, value) => interactor.find(TextField())
+      .perform((el) => {
+        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value');
+        property.set.call(el, value);
+        el.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
+      })
+  }
+});
+
+

--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -5,6 +5,7 @@ import IconButton from './icon-button';
 
 export default createInteractor('datepicker')({
   selector: '[data-test-datepicker-container]',
+  locator: (el) => el.querySelector('label').textContent,
   filters: {
     id: (el) => el.querySelector('input').id,
     inputValue: (el) => el.querySelector('div[class^=textField] input').value,
@@ -38,7 +39,6 @@ export default createInteractor('datepicker')({
     openCalendar: (interactor) => interactor.find(IconButton({ icon: 'calendar' })).click(),
     clear: (interactor) => interactor.find(IconButton({ icon: 'times-circle-solid' })).click(),
     click: perform((el) => { el.click(); }),
-    focusInput: (interactor) => interactor.find(TextField()).focus(),
     fillIn: (interactor, value) => interactor.find(TextField()).fillIn(value),
     focus: (interactor) => interactor.find(TextField()).focus(),
     blur: (interactor) => interactor.find(TextField()).blur(),
@@ -53,14 +53,6 @@ const CalendarDays = createInteractor('calendar days')({
     } else {
       return el.textContent;
     }
-  },
-  filters: {
-    selected: (el) => !!el.querySelector('div').className.match(/selected-/),
-    dateSelected: (el) => el.getAttribute('data-date'),
-    disabled: (el) => el.querySelector('div').hasAttribute('data-excluded'),
-    month: (el) => el.getAttribute('data-date').split('/')[0],
-    year: (el) => el.getAttribute('data-date').split('/')[2],
-    focused
   },
   actions: {
     click: perform((el) => { el.click(); }),
@@ -121,5 +113,3 @@ export const Calendar = createInteractor('calendar widget')({
       })
   }
 });
-
-

--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -72,6 +72,7 @@ export const Calendar = createInteractor('calendar widget')({
     today: (el) => format(parseISO(el.querySelector('td[tabindex="0"]').getAttribute('data-day')), 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd'),
     month: (el) => el.querySelector('select').selectedOptions[0].label || '',
     year: (el) => el.querySelector('input').value,
+    day: (el) => (!el.querySelector('[class^=selected-]') ? '' : el.querySelector('[class^=selected-]').textContent),
     days: (el) => Array.from(el.querySelectorAll('td')).reduce(
       (days, node) => {
         if (node.getAttribute('data-excluded') !== 'true') {

--- a/interactors/html.js
+++ b/interactors/html.js
@@ -1,10 +1,14 @@
-import { createInteractor, focused } from '@bigtest/interactor';
+import { createInteractor, perform, focused } from '@bigtest/interactor';
 
 export default createInteractor('element')({
   selector: '*',
   locator: (el) => el.textContent,
   filters: {
     id: (el) => el.id,
+    text: (el) => el.textContent,
     focused
+  },
+  actions: {
+    click: perform((el) => { el.click(); }),
   }
 });

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -1,3 +1,9 @@
+import * as Bigtest from '@bigtest/interactor';
+
+export { Bigtest };
+
+export { default as Checkbox } from './checkbox';
+export { default as Datepicker, Calendar } from './datepicker';
 export { default as Accordion } from './accordion';
 export { default as Button } from './button';
 export { default as Checkbox } from './checkbox';
@@ -16,5 +22,12 @@ export { default as TextField } from './text-field';
 export { default as Dropdown } from './dropdown';
 export { default as TextArea } from './textarea';
 export { Tooltip, TooltipProximity } from './tooltip';
-
+export { default as Layer } from './layer';
 export { default as converge } from './converge';
+export { default as RadioButton } from './radio-button';
+export { default as Select } from './select';
+export { default as Label } from './label';
+export { default as Button } from './button';
+export { default as Pane } from './pane';
+export { default as TextField } from './text-field';
+export { default as HTML } from './html';

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -1,12 +1,12 @@
 import * as Bigtest from '@bigtest/interactor';
 
 export { Bigtest };
+export { default as converge } from './converge';
 
-export { default as Checkbox } from './checkbox';
-export { default as Datepicker, Calendar } from './datepicker';
 export { default as Accordion } from './accordion';
 export { default as Button } from './button';
 export { default as Checkbox } from './checkbox';
+export { default as Datepicker, Calendar } from './datepicker';
 export { default as HTML } from './html';
 export { default as IconButton } from './icon-button';
 export { default as KeyValue } from './key-value';
@@ -19,15 +19,5 @@ export { default as RadioButton } from './radio-button';
 export { default as SearchField } from './search-field';
 export { default as Select } from './select';
 export { default as TextField } from './text-field';
-export { default as Dropdown } from './dropdown';
 export { default as TextArea } from './textarea';
 export { Tooltip, TooltipProximity } from './tooltip';
-export { default as Layer } from './layer';
-export { default as converge } from './converge';
-export { default as RadioButton } from './radio-button';
-export { default as Select } from './select';
-export { default as Label } from './label';
-export { default as Button } from './button';
-export { default as Pane } from './pane';
-export { default as TextField } from './text-field';
-export { default as HTML } from './html';

--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -2,14 +2,21 @@
 
 import { createInteractor, perform } from '@bigtest/interactor';
 
-export default createInteractor('keyboard')({
+export default createInteractor('keyboard (requires window to have focus)')({
   selector: ':focus',
   actions: {
     arrowUp: press('ArrowUp'),
     arrowDown: press('ArrowDown'),
+    arrowLeft: press('ArrowLeft'),
+    arrowRight: press('ArrowRight'),
+    pageUp: press('PageUp'),
+    pageDown: press('PageDown'),
     home: press('Home'),
     end: press('End'),
-    escape: press('Escape')
+    enter: press('Enter'),
+    escape: press('Escape'),
+    alt: press('AltLeft'),
+    altLeft: press('AltLeft')
   }
 })();
 
@@ -17,9 +24,15 @@ export default createInteractor('keyboard')({
 const KEY_CODES = {
   ArrowDown: 40,
   ArrowUp: 38,
+  ArrowLeft: 37,
+  ArrowRight: 39,
+  PageUp: 33,
+  PageDown: 34,
   Home: 36,
   End: 35,
+  Enter: 13,
   Escape: 27,
+  AltLeft: 18
 };
 
 

--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -2,6 +2,7 @@
 
 import { createInteractor, perform, Select } from '@bigtest/interactor';
 
+
 export default createInteractor('keyboard (requires window to have focus)')({
   selector: ':focus',
   actions: {
@@ -41,8 +42,8 @@ export default createInteractor('keyboard (requires window to have focus)')({
         el.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
       }
     }),
-    pageUp: press('PageUp'),
-    pageDown: press('PageDown'),
+    pageUp: (interactor, options) => press('PageUp', options)(interactor),
+    pageDown: (interactor, options) => press('PageDown', options)(interactor),
     home: press('Home'),
     end: press('End'),
     enter: press('Enter'),
@@ -67,23 +68,23 @@ const KEY_CODES = {
 };
 
 
-function press(code) {
+function press(code, options) {
   return perform(async function (el) {
-    if (await dispatch(el, 'keydown', code)) {
-      await dispatch(el, 'keyup', code);
+    if (await dispatch(el, 'keydown', code, options)) {
+      await dispatch(el, 'keyup', code, options);
     }
   });
 }
 
-function dispatch(element, eventType, code) {
+function dispatch(element, eventType, code, options) {
   return new Promise((resolve, reject) => {
     try {
       const KeyboardEvent = element.ownerDocument.defaultView.KeyboardEvent;
       const event = new KeyboardEvent(eventType, {
-        altKey: false,
+        altKey: (options && options.altKey) || false,
         code,
         keyCode: KEY_CODES[code],
-        ctrlKey: false,
+        ctrlKey: (options && options.ctrlKey) || false,
         key: code,
         bubbles: true,
         cancelable: true

--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -10,37 +10,34 @@ export default createInteractor('keyboard (requires window to have focus)')({
     arrowDown: press('ArrowDown'),
     arrowLeft: press('ArrowLeft'),
     arrowRight: press('ArrowRight'),
-    // using an underscore to signify that this is a temporary workaround
-    // we want to use the default browser implementation, but it doesn't
-    // trigger the built-in browser functions so we will need a more
-    // fleshed out approach to this
-    _nextOption: perform(async (el) => {
-      if (el.localName === 'select') {
-        const options = el.querySelectorAll('option');
-        const nextValue = parseInt(el.value, 10) === options.length - 1
-          ? '0'
-          : `${parseInt(el.value, 10) + 1}`;
-        await Select().choose(options.item(nextValue).textContent);
-      } else {
-        const value = `${parseInt(el.value, 10) + 1}`;
-        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value');
-        property.set.call(el, value);
-        el.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
-      }
+    // next/prevOption and increment/decrementNumber are workarounds
+    // as we want to use the default browser implementation,
+    // but it doesn't trigger the built-in browser functions
+    nextOption: perform(async (el) => {
+      const options = el.querySelectorAll('option');
+      const nextValue = parseInt(el.value, 10) === options.length - 1
+        ? '0'
+        : `${parseInt(el.value, 10) + 1}`;
+      await Select().choose(options.item(nextValue).textContent);
     }),
-    _prevOption: perform(async (el) => {
-      if (el.localName === 'select') {
-        const options = el.querySelectorAll('option');
-        const nextValue = parseInt(el.value, 10) === 0
-          ? `${options.length() - 1}`
-          : `${parseInt(el.value, 10) - 1}`;
-        await Select().choose(options.item(nextValue).textContent);
-      } else {
-        const value = `${parseInt(el.value, 10) - 1}`;
-        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value');
-        property.set.call(el, value);
-        el.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
-      }
+    prevOption: perform(async (el) => {
+      const options = el.querySelectorAll('option');
+      const nextValue = parseInt(el.value, 10) === 0
+        ? `${options.length() - 1}`
+        : `${parseInt(el.value, 10) - 1}`;
+      await Select().choose(options.item(nextValue).textContent);
+    }),
+    incrementNumber: perform(async (el) => {
+      const value = `${parseInt(el.value, 10) + 1}`;
+      const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value');
+      property.set.call(el, value);
+      el.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
+    }),
+    decrementNumber: perform(async (el) => {
+      const value = `${parseInt(el.value, 10) - 1}`;
+      const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value');
+      property.set.call(el, value);
+      el.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
     }),
     pageUp: (interactor, options) => press('PageUp', options)(interactor),
     pageDown: (interactor, options) => press('PageDown', options)(interactor),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@bigtest/interactor": "^0.23.0",
+    "date-fns": "^2.16.1",
     "debug": "^4.0.1",
     "element-is-visible": "^1.0.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
## Motivation
Upgrade the Datepicker and Calendar interactor to the new bigtest interactor syntax. Make it available for usage in the test suite.

## Approach
Added a Datepicker and Calendar interactor, with filters and actions for interacting with both the datepicker input field and the calendar widget.

The related `stripes-components` PR will not be opened until this one has been merged in. The related code can be seen [here](https://github.com/jbolda/stripes-components/commit/98583a519e01b65f59267426e828e029ebf62e21) until it is opened.

## Outstanding
Note the tests that are currently skipped. Overall we are missing some pieces to test the keyboard functionality. This will likely fall into the keyboard interactor and not be in the datepicker interactor, but still makes sense to include it in the scope of this PR. 

It also makes sense to include `CalendarDays` more fully within the `Calendar` interactor and expose it as a public API, but need to work out what that will look like.