### PR TITLE
Upgrade `@bigtest/interactor` package to `@interactors/html`

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,5 +1,5 @@
 import { bigtestGlobals } from '@bigtest/globals';
-import '@bigtest/cypress';
+import '@interactors/with-cypress';
 
 import './stripes';
 

--- a/doc/differences-in-stripes-components-testing.md
+++ b/doc/differences-in-stripes-components-testing.md
@@ -4,7 +4,7 @@
 * [Waiting on elements instead of delays](#waiting-on-elements-instead-of-delays)
 * [Using Karma instead of Nightmare](#using-karma-instead-of-nightmare)
 * [Using `@bigtest/mocha` instead of regular Mocha](#using-bigtestmocha-instead-of-regular-mocha)
-* [Using `@bigtest/interactor` to provide short-cuts](#using-bigtestinteractor-to-provide-short-cuts)
+* [Using `@interactors/html` to provide short-cuts](#using-interactorshtml-to-provide-short-cuts)
 * [Starting tests with `stripes test`](#starting-tests-with-stripes-test)
 
 
@@ -47,12 +47,11 @@ On the positive side, this allows `.wait` actions to be omitted altogether. On t
 
 I'm not convinced that the unpredictable cost of this approach is necessarily worth the gain. We can consider whether to shift to using `@bigtest/mocha`, but it's not an obvious move.
 
+## Using `@interactors/html` to provide short-cuts
 
-## Using `@bigtest/interactor` to provide short-cuts
+[`@interactors/html`](https://github.com/thefrontside/interactors) is another part of Frontside's "BigTest" suite, providing useful short-cuts for some browser automation sequences, and the ability to define and use re-usable "macros".
 
-[`@bigtestjs/interactor`](https://github.com/bigtestjs/interactor) is another part of Frontside's "BigTest" suite, providing useful short-cuts for some browser automation sequences, and the ability to define and use re-usable "macros".
-
-This looks like a powerful way to build tests of UIs, and may well be worth adopting: see the `logIn` example at the start of [the top-level README](https://github.com/bigtestjs/interactor/blob/master/README.md).
+This looks like a powerful way to build tests of UIs, and may well be worth adopting: see the `logIn` example at the start of [the top-level README](https://github.com/thefrontside/interactors/blob/master/README.md).
 
 But using interactors requires the "convergent" style and so may imply or necessitate the use of `@bigtest/mocha`. Also, it may require using Karma instead of Nightmare, which is a switch we may not want to make -- or not yet.
 

--- a/interactors/accordion.js
+++ b/interactors/accordion.js
@@ -1,4 +1,4 @@
-import { Button } from '@bigtest/interactor';
+import { Button } from '@interactors/html';
 import { isVisible } from 'element-is-visible';
 import HTML from './baseHTML';
 

--- a/interactors/baseHTML.js
+++ b/interactors/baseHTML.js
@@ -1,4 +1,4 @@
-import { HTML as BaseHTML } from '@bigtest/interactor';
+import { HTML as BaseHTML } from '@interactors/html';
 
 export default BaseHTML
   .filters({

--- a/interactors/checkbox.js
+++ b/interactors/checkbox.js
@@ -1,4 +1,4 @@
-import { CheckBox } from '@bigtest/interactor';
+import { CheckBox } from '@interactors/html';
 import HTML from './baseHTML';
 
 export default HTML.extend('checkbox')

--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -1,4 +1,4 @@
-import { createInteractor, TextField, Select } from '@bigtest/interactor';
+import { createInteractor, TextField, Select } from '@interactors/html';
 import { isVisible } from 'element-is-visible';
 import { format, parseISO } from 'date-fns';
 import IconButton from './icon-button';

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -1,7 +1,7 @@
-import * as Bigtest from '@bigtest/interactor';
+import * as Bigtest from '@interactors/html';
 
 export { Bigtest };
-export { Heading, HTML, including, Link, matching, and, or, not, some, every, isVisible, Page } from '@bigtest/interactor';
+export { Heading, HTML, including, Link, matching, and, or, not, some, every, isVisible, Page } from '@interactors/html';
 export { default as converge } from './converge';
 
 export { default as Accordion } from './accordion';

--- a/interactors/key-value.js
+++ b/interactors/key-value.js
@@ -1,4 +1,4 @@
-import { createInteractor } from '@bigtest/interactor';
+import { createInteractor } from '@interactors/html';
 
 export default createInteractor('key value')
   .selector('[class^=kvRoot]')

--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import { createInteractor, Select } from '@bigtest/interactor';
+import { createInteractor, Select } from '@interactors/html';
 
 
 export default createInteractor('keyboard (requires window to have focus)')

--- a/interactors/layer.js
+++ b/interactors/layer.js
@@ -1,4 +1,4 @@
-import { createInteractor, focused } from '@bigtest/interactor';
+import { createInteractor, focused } from '@interactors/html';
 import { isVisible } from 'element-is-visible';
 
 export default createInteractor('layer')

--- a/interactors/list.js
+++ b/interactors/list.js
@@ -1,4 +1,4 @@
-import { createInteractor, HTML } from '@bigtest/interactor';
+import { createInteractor, HTML } from '@interactors/html';
 
 const childIndex = el => [...el.parentElement.children].indexOf(el);
 

--- a/interactors/multi-column-list.js
+++ b/interactors/multi-column-list.js
@@ -1,4 +1,4 @@
-import { isVisible, Button } from '@bigtest/interactor';
+import { isVisible, Button } from '@interactors/html';
 import HTML from './baseHTML';
 
 const childIndex = el => [...el.parentElement.children].indexOf(el);

--- a/interactors/multi-select.js
+++ b/interactors/multi-select.js
@@ -1,4 +1,4 @@
-import { createInteractor, HTML, including, TextField } from '@bigtest/interactor';
+import { createInteractor, HTML, including, TextField } from '@interactors/html';
 import Button from './button';
 
 const open = (el) => el.getAttribute('aria-expanded') === 'true';

--- a/interactors/radio-button.js
+++ b/interactors/radio-button.js
@@ -1,3 +1,4 @@
+import { RadioButton } from '@interactors/html';
 import HTML from './baseHTML';
 
 export default HTML.extend('radio button')
@@ -20,10 +21,6 @@ export default HTML.extend('radio button')
   })
   .actions({
     click: ({ perform }) => perform((el) => { el.querySelector('label').click(); }),
-    focus: ({ perform }) => perform((el) => { el.querySelector('input').focus(); }),
-    blur: ({ perform }) => perform((el) => { el.querySelector('input').blur(); }),
-    // TODO: when @bigtest/interactors version gets bumped, we can find
-    // the built-in radio button interactor instead
-    // focus: (interactor) => { interactor.find(RadioButton()).focus(); },
-    // blur: (interactor) => { interactor.find(RadioButton()).blur(); },
+    focus: ({ find }) => { find(RadioButton()).focus(); },
+    blur: ({ find }) => { find(RadioButton()).blur(); },
   });

--- a/interactors/rich-text-editor.js
+++ b/interactors/rich-text-editor.js
@@ -1,4 +1,4 @@
-import { HTML } from '@bigtest/interactor';
+import { HTML } from '@interactors/html';
 
 function label(el) {
   return el.querySelector('label').innerText;

--- a/interactors/search-field.js
+++ b/interactors/search-field.js
@@ -1,4 +1,4 @@
-import { TextField, Select } from '@bigtest/interactor';
+import { TextField, Select } from '@interactors/html';
 import HTML from './baseHTML';
 
 const label = (el) => {

--- a/interactors/select.js
+++ b/interactors/select.js
@@ -1,4 +1,4 @@
-import { Select } from '@bigtest/interactor';
+import { Select } from '@interactors/html';
 import HTML from './baseHTML';
 
 function label(el) {

--- a/interactors/text-field.js
+++ b/interactors/text-field.js
@@ -1,4 +1,4 @@
-import { TextField } from '@bigtest/interactor';
+import { TextField } from '@interactors/html';
 import HTML from './baseHTML';
 
 import IconButton from './icon-button';

--- a/interactors/textarea.js
+++ b/interactors/textarea.js
@@ -1,4 +1,4 @@
-import { TextField } from '@bigtest/interactor';
+import { TextField } from '@interactors/html';
 import HTML from './baseHTML';
 
 const label = (el) => {

--- a/interactors/tooltip.js
+++ b/interactors/tooltip.js
@@ -1,4 +1,4 @@
-import { createInteractor } from '@bigtest/interactor';
+import { createInteractor } from '@interactors/html';
 import { isVisible } from 'element-is-visible';
 
 export const Tooltip = createInteractor('tooltip')

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@bigtest/interactor": "^0.31.1",
+    "@interactors/html": "^0.32.0",
     "date-fns": "^2.16.1",
     "debug": "^4.0.1",
     "element-is-visible": "^1.0.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "@bigtest/cypress": "^0.1.1",
     "@folio/eslint-config-stripes": "^5.0.0",
+    "@interactors/with-cypress": "^0.1.2",
     "bigtest": "^0.14.0",
     "cypress": "^6.8.0",
     "eslint": "^7.15.0",


### PR DESCRIPTION
Interactors are independently useful outside of BigTest and can be used in many different contexts including both Jest and Cypress, so after observing how they were being used in the wild, it didn’t make sense to keep it coupled to BigTest development.

As an independent project, the documentation, APIs, and community can evolve independently without any artificial limits.

The `@bigtest/interactor` and `@bigtest/cypress` projects have been moved in separate monorepo https://github.com/thefrontside/interactors and related packages had been deprecated. I updated dependencies to use actual packages `@interactors/html` and `@interactors/with-cypress` instead.