### PR TITLE
Switch innerText to textContent in interactors

### DIFF
--- a/interactors/accordion.js
+++ b/interactors/accordion.js
@@ -4,7 +4,7 @@ import HTML from './baseHTML';
 
 function label(element) {
   const labelEl = element.querySelector('[class^=labelArea]');
-  return labelEl ? labelEl.innerText.trim() : '';
+  return labelEl ? labelEl.textContent.trim() : '';
 }
 
 export default HTML.extend('accordion')

--- a/interactors/autosuggest.js
+++ b/interactors/autosuggest.js
@@ -27,11 +27,11 @@ const clearInput = (element) => {
 
 const AutoSuggestOption = HTML.extend('auto-suggest option')
   .selector('[role=option]')
-  .locator(el => el.innerText || '');
+  .locator(el => el.textContent || '');
 
 export default HTML.extend('auto-suggest')
   .selector('[class^=downshift-]')
-  .locator(el => el.querySelector('label').innerText)
+  .locator(el => el.querySelector('label').textContent)
   .filters({
     open,
     selected: (element) => {
@@ -40,7 +40,7 @@ export default HTML.extend('auto-suggest')
       if (!valueList) return [];
 
       return Array.from(valueList.querySelectorAll('[role=option]'))
-        .map(option => option.innerText || '')
+        .map(option => option.textContent || '')
         .filter(Boolean);
     },
     value: (el => el.querySelector('input').value),

--- a/interactors/badge.js
+++ b/interactors/badge.js
@@ -4,8 +4,8 @@ const color = (element) => element.className;
 
 export default HTML.extend('badge')
   .selector('[class^=badge-]')
-  .locator(element => element.querySelector('[class^=label-]').innerText)
+  .locator(element => element.querySelector('[class^=label-]').textContent)
   .filters({
     color,
-    value: (element) => element.querySelector('[class^=label-]').innerText
+    value: (element) => element.querySelector('[class^=label-]').textContent
   });

--- a/interactors/checkbox.js
+++ b/interactors/checkbox.js
@@ -7,17 +7,17 @@ export default HTML.extend('checkbox')
   .locator((el) => {
     const labelText = el.querySelector('[class^=labelText]');
     const input = el.querySelector('input');
-    return labelText ? labelText.innerText : input.getAttribute('aria-label') || '';
+    return labelText ? labelText.textContent : input.getAttribute('aria-label') || '';
   })
   .filters({
     id: (el) => el.querySelector('input').id,
     checked: (el) => el.querySelector('input').checked,
     valid: (el) => el.querySelector('input').validity.valid,
     value: (el) => el.querySelector('input').value,
-    label: (el) => el.innerText,
+    label: (el) => el.textContent,
     ariaLabel: (el) => el.querySelector('input').ariaLabel,
     ariaInvalid: (el) => el.querySelector('input').getAttribute('aria-invalid') === 'true',
-    feedbackText: (el) => el.querySelector('[role=alert]').innerText,
+    feedbackText: (el) => el.querySelector('[role=alert]').textContent,
     hasWarning: (el) => !!el.className.match(/hasWarning/),
     hasError: (el) => !!el.className.match(/hasError/),
     disabled: {

--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -7,13 +7,13 @@ import HTML from './baseHTML';
 
 export default HTML.extend('datepicker')
   .selector('[data-test-datepicker-container]')
-  .locator((el) => el.querySelector('label').innerText)
+  .locator((el) => el.querySelector('label').textContent)
   .filters({
     id: (el) => el.querySelector('input').id,
     inputValue: (el) => el.querySelector('div[class^=textField] input').value,
     inputDay: (el) => Date(el.querySelector('div[class^=textField] input').value).getDay(),
     placeholder: (el) => el.querySelector('div[class^=textField] input').placeholder,
-    label: (el) => el.querySelector('label').innerText,
+    label: (el) => el.querySelector('label').textContent,
     warning: (el) => (
       !el.querySelector('[role=alert] div')
         ? false
@@ -49,10 +49,10 @@ export default HTML.extend('datepicker')
 const CalendarDays = HTML.extend('calendar days')
   .selector('[class^=calendar-] td')
   .locator((el) => {
-    if (el.innerText.length === 1) {
-      return `0${el.innerText}`;
+    if (el.textContent.length === 1) {
+      return `0${el.textContent}`;
     } else {
-      return el.innerText;
+      return el.textContent;
     }
   });
 
@@ -71,14 +71,14 @@ export const Calendar = createInteractor('calendar widget')
     today: (el) => format(parseISO(el.querySelector('td[tabindex="0"]').getAttribute('data-day')), 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd'),
     month: (el) => el.querySelector('select').selectedOptions[0].label || '',
     year: (el) => el.querySelector('input').value,
-    day: (el) => (!el.querySelector('[class^=selected-]') ? '' : el.querySelector('[class^=selected-]').innerText),
+    day: (el) => (!el.querySelector('[class^=selected-]') ? '' : el.querySelector('[class^=selected-]').textContent),
     days: (el) => Array.from(el.querySelectorAll('td')).reduce(
       (days, node) => {
         if (node.getAttribute('data-excluded') !== 'true') {
           if (node.querySelector('[class*=muted-]')) {
-            return days.concat([`_${node.innerText}_`]);
+            return days.concat([`_${node.textContent}_`]);
           } else {
-            return days.concat([node.innerText]);
+            return days.concat([node.textContent]);
           }
         } else {
           return days;
@@ -89,9 +89,9 @@ export const Calendar = createInteractor('calendar widget')
       (days, node) => {
         if (node.getAttribute('data-excluded') === 'true') {
           if (node.querySelector('[class*=muted-]')) {
-            return days.concat([`_${node.innerText}_`]);
+            return days.concat([`_${node.textContent}_`]);
           } else {
-            return days.concat([node.innerText]);
+            return days.concat([node.textContent]);
           }
         } else {
           return days;

--- a/interactors/dropdown.js
+++ b/interactors/dropdown.js
@@ -11,7 +11,7 @@ const DropdownMenu = HTML.extend('dropdown menu')
 
 const label = el => {
   const node = el.querySelector('[aria-haspopup]');
-  return node ? node.getAttribute('aria-label') || node.innerText : null;
+  return node ? node.getAttribute('aria-label') || node.textContent : null;
 };
 
 const open = el => el.querySelector('[aria-haspopup]').getAttribute('aria-expanded') === 'true';

--- a/interactors/key-value.js
+++ b/interactors/key-value.js
@@ -2,8 +2,8 @@ import { createInteractor } from '@interactors/html';
 
 export default createInteractor('key value')
   .selector('[class^=kvRoot]')
-  .locator((el) => el.querySelector('[class^=kvLabel]').innerText)
+  .locator((el) => el.querySelector('[class^=kvLabel]').textContent)
   .filters({
-    value: (el) => el.querySelector('[class^=kvValue]').innerText,
-    subValue: (el) => el.querySelector('[class^=kvSub]').innerText
+    value: (el) => el.querySelector('[class^=kvValue]').textContent,
+    subValue: (el) => el.querySelector('[class^=kvSub]').textContent
   });

--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -19,14 +19,14 @@ export default createInteractor('keyboard (requires window to have focus)')
       const nextValue = parseInt(el.value, 10) === options.length - 1
         ? '0'
         : `${parseInt(el.value, 10) + 1}`;
-      await Select().choose(options.item(nextValue).innerText);
+      await Select().choose(options.item(nextValue).textContent);
     }),
     prevOption: ({ perform }) => perform(async (el) => {
       const options = el.querySelectorAll('option');
       const nextValue = parseInt(el.value, 10) === 0
         ? `${options.length() - 1}`
         : `${parseInt(el.value, 10) - 1}`;
-      await Select().choose(options.item(nextValue).innerText);
+      await Select().choose(options.item(nextValue).textContent);
     }),
     incrementNumber: ({ perform }) => perform(async (el) => {
       const value = `${parseInt(el.value, 10) + 1}`;

--- a/interactors/label.js
+++ b/interactors/label.js
@@ -2,7 +2,7 @@ import HTML from './baseHTML';
 
 export default HTML.extend('label')
   .selector('label')
-  .locator((el) => el.innerText)
+  .locator((el) => el.textContent)
   .filters({
     for: (el) => el.htmlFor,
   });

--- a/interactors/modal.js
+++ b/interactors/modal.js
@@ -1,7 +1,7 @@
 import Button from './button';
 import HTML from './baseHTML';
 
-function title(el) { return el.querySelector('[class^=modalHeader]').innerText; }
+function title(el) { return el.querySelector('[class^=modalHeader]').textContent; }
 
 export default HTML.extend('modal')
   .selector('[class^=modal-]')

--- a/interactors/multi-column-list.js
+++ b/interactors/multi-column-list.js
@@ -3,7 +3,7 @@ import HTML from './baseHTML';
 
 const childIndex = el => [...el.parentElement.children].indexOf(el);
 
-const content = el => el.innerText;
+const content = el => el.textContent;
 
 export const MultiColumnListRow = HTML.extend('multi column list row')
   .selector('[data-row-inner]')
@@ -19,7 +19,7 @@ export const MultiColumnListCell = HTML.extend('multi column list cell')
   .filters({
     content,
     row: el => +el.parentElement.getAttribute('data-row-inner'),
-    column: (el) => el.innerText,
+    column: (el) => el.textContent,
     columnIndex: childIndex,
     selected: (el) => !!el.parentElement.className.match(/mclSelected/),
     measured: (el) => el.style && el.style.width !== '',
@@ -35,7 +35,7 @@ const MultiColumnListHeader = HTML.extend('multi column list header')
     click: ({ perform }) => perform(el => el.querySelector('[role=button]').click()),
   });
 
-const columns = el => [...el.querySelectorAll('[class*=mclHeader-]')].map(x => x.innerText);
+const columns = el => [...el.querySelectorAll('[class*=mclHeader-]')].map(x => x.textContent);
 
 export const MultiColumnList = HTML.extend('multi column list')
   .selector('div[class*=mclContainer-]')

--- a/interactors/multi-select.js
+++ b/interactors/multi-select.js
@@ -15,12 +15,12 @@ const control = ({ shouldOpen = true } = {}) => async interactor => {
 
 const MultiSelectOption = HTML.extend('multi select option')
   .selector('[class^=multiSelectOption-]')
-  .locator(el => el.querySelector('[class^=valueChipValue-]').innerText || '');
+  .locator(el => el.querySelector('[class^=valueChipValue-]').textContent || '');
 
 export default createInteractor('multi select')
   .locator(el => {
     const label = document.getElementById(el.getAttribute('aria-labelledby'));
-    return (label && label.innerText) || '';
+    return (label && label.textContent) || '';
   })
   .selector('[role=application][class^=multiSelectContainer-]')
   .filters({
@@ -31,7 +31,7 @@ export default createInteractor('multi select')
       if (!valueList) return [];
 
       return Array.from(valueList.querySelectorAll('[class^=valueChipValue-]'))
-        .map(valueChip => valueChip.innerText || '')
+        .map(valueChip => valueChip.textContent || '')
         .filter(Boolean);
     }
   })

--- a/interactors/pane.js
+++ b/interactors/pane.js
@@ -2,7 +2,7 @@ import { isVisible } from 'element-is-visible';
 import Button from './button';
 import HTML from './baseHTML';
 
-function title(el) { return el.querySelector('[class^=paneTitle]').innerText; }
+function title(el) { return el.querySelector('[class^=paneTitle]').textContent; }
 
 export const PaneHeader = HTML.extend('pane header')
   .selector('[class^=paneHeader-]')
@@ -13,7 +13,7 @@ export default HTML.extend('pane')
   .locator(title)
   .filters({
     title,
-    subtitle: (el) => el.querySelector('[class^=paneSub]').innerText,
+    subtitle: (el) => el.querySelector('[class^=paneSub]').textContent,
     visible: {
       apply: (el) => isVisible(el) || (el.labels && Array.from(el.labels).some(isVisible)),
       default: true

--- a/interactors/radio-button.js
+++ b/interactors/radio-button.js
@@ -4,15 +4,15 @@ import HTML from './baseHTML';
 
 export default HTML.extend('radio button')
   .selector('div[class^=radioButton]')
-  .locator((el) => el.querySelector('[class^=labelText]').innerText)
+  .locator((el) => el.querySelector('[class^=labelText]').textContent)
   .filters({
     title: (el) => el.querySelector('input').title,
     id: (el) => el.querySelector('input').id,
     valid: (el) => el.querySelector('input').validity.valid,
     checked: (el) => el.querySelector('input').checked,
     value: (el) => el.querySelector('input').value,
-    label: (el) => el.innerText,
-    feedbackText: (el) => el.querySelector('[class^=radioFeedback]').innerText,
+    label: (el) => el.textContent,
+    feedbackText: (el) => el.querySelector('[class^=radioFeedback]').textContent,
     hasWarning: (el) => !!el.className.match(/hasWarning/),
     hasError: (el) => !!el.className.match(/hasError/),
     disabled: {

--- a/interactors/repeatablefield.js
+++ b/interactors/repeatablefield.js
@@ -16,10 +16,10 @@ const FieldList = HTML.extend('repeatable field list')
 // find by legend
 export const RepeatableField = HTML.extend('repeatable field')
   .selector('fieldset[data-test-repeatable-field')
-  .locator(el => el.querySelector('legend').innerText)
+  .locator(el => el.querySelector('legend').textContent)
   .filters({
     id: (el) => el.id,
-    emptyMessage: (el) => el.querySelector('[class^=emptyMessage]').innerText,
+    emptyMessage: (el) => el.querySelector('[class^=emptyMessage]').textContent,
     removeButton: (el) => !!el.querySelector('[data-test-repeatable-field-remove-item-button]'),
     addButton: (el) => !!el.querySelector('[data-test-repeatable-field-add-item-button]'),
     addButtonId: (el) => el.querySelector('[data-test-repeatable-field-add-item-button]').id,

--- a/interactors/rich-text-editor.js
+++ b/interactors/rich-text-editor.js
@@ -1,18 +1,18 @@
 import { HTML } from '@interactors/html';
 
 function label(el) {
-  return el.querySelector('label').innerText;
+  return el.querySelector('label').textContent;
 }
 
 export default HTML.extend('rich text editor')
   .selector('[class^=inputGroup]')
   .locator(label)
   .filters({
-    value: (element) => element.querySelector('.ql-editor').innerText
+    value: (element) => element.querySelector('.ql-editor').textContent
   })
   .actions({
     fillIn: ({ perform }, value) => perform(element => {
       const editor = element.querySelector('.ql-editor');
-      if (editor) editor.innerText = value;
+      if (editor) editor.textContent = value;
     })
   });

--- a/interactors/search-field.js
+++ b/interactors/search-field.js
@@ -3,7 +3,7 @@ import HTML from './baseHTML';
 
 const label = (el) => {
   const labelText = el.querySelector('label');
-  return labelText ? labelText.innerText : undefined;
+  return labelText ? labelText.textContent : undefined;
 };
 
 export default HTML.extend('search field')

--- a/interactors/select.js
+++ b/interactors/select.js
@@ -4,7 +4,7 @@ import HTML from './baseHTML';
 
 function label(el) {
   const container = el.querySelector('label');
-  return container ? container.innerText : undefined;
+  return container ? container.textContent : undefined;
 }
 
 const choose = (intr, value) => intr.find(Select()).choose(value);
@@ -23,11 +23,11 @@ export default HTML.extend('select')
     value: el => el.querySelector('select').value,
     error: el => {
       const feedbackError = el.querySelector('[class^=feedbackError]');
-      return feedbackError ? feedbackError.innerText : undefined;
+      return feedbackError ? feedbackError.textContent : undefined;
     },
     warning: el => {
       const feedbackWarning = el.querySelector('[class^=feedbackWarning]');
-      return feedbackWarning ? feedbackWarning.innerText : undefined;
+      return feedbackWarning ? feedbackWarning.textContent : undefined;
     },
     valid: el => el.querySelector('select').getAttribute('aria-invalid') !== 'true',
   })

--- a/interactors/text-field.js
+++ b/interactors/text-field.js
@@ -8,7 +8,7 @@ const label = (el) => {
   let labelEl = el.querySelector('label');
   const input = el.querySelector('input');
   if (!labelEl) labelEl = input ? (input.labels || [])[0] : null;
-  return labelEl ? labelEl.innerText : input.getAttribute('aria-label') || '';
+  return labelEl ? labelEl.textContent : input.getAttribute('aria-label') || '';
 };
 
 export default HTML.extend('text field')
@@ -21,10 +21,10 @@ export default HTML.extend('text field')
     value: (el) => el.querySelector('input').value,
     focused: (el) => el.querySelector('input').contains(el.ownerDocument.activeElement),
     readOnly: (el) => el.querySelector('input').hasAttribute('readOnly'),
-    startControl: (el) => el.querySelector('[class^=startControls').innerText,
-    endControl: (el) => el.querySelector('[class^=endControls').innerText,
-    error: (el) => (el.querySelector('[class*=feedbackError-]') || {}).innerText,
-    warning: (el) => (el.querySelector('[class*=feedbackWarning-]') || {}).innerText,
+    startControl: (el) => el.querySelector('[class^=startControls').textContent,
+    endControl: (el) => el.querySelector('[class^=endControls').textContent,
+    error: (el) => (el.querySelector('[class*=feedbackError-]') || {}).textContent,
+    warning: (el) => (el.querySelector('[class*=feedbackWarning-]') || {}).textContent,
     valid: el => el.querySelector('input').getAttribute('aria-invalid') !== 'true',
     clearButton: el => {
       const clearBtn = [...el.querySelectorAll('[class^=iconButton]')]

--- a/interactors/textarea.js
+++ b/interactors/textarea.js
@@ -4,7 +4,7 @@ import HTML from './baseHTML';
 
 const label = (el) => {
   const labelText = el.querySelector('label');
-  return labelText ? labelText.innerText : undefined;
+  return labelText ? labelText.textContent : undefined;
 };
 
 export default HTML.extend('text area')
@@ -14,8 +14,8 @@ export default HTML.extend('text area')
     id: el => el.querySelector('textarea').getAttribute('id'),
     label,
     value: el => el.querySelector('textarea').value,
-    warning: el => el.querySelector('[class^=feedbackWarning-]').innerText,
-    error: el => el.querySelector('[class^=feedbackError-]').innerText,
+    warning: el => el.querySelector('[class^=feedbackWarning-]').textContent,
+    error: el => el.querySelector('[class^=feedbackError-]').textContent,
     valid: el => el.querySelector('textarea').getAttribute('aria-invalid') !== 'true'
   })
   .actions({

--- a/interactors/tooltip.js
+++ b/interactors/tooltip.js
@@ -4,11 +4,11 @@ import { isVisible } from 'element-is-visible';
 export const Tooltip = createInteractor('tooltip')
   .selector('[class^=tooltip], [data-test-tooltip-proximity-element]')
   .locator((el) => {
-    return el.querySelector('[class^=text], span[role=tooltip]').innerText;
+    return el.querySelector('[class^=text], span[role=tooltip]').textContent;
   })
   .filters({
-    text: (el) => el.querySelector('[class^=text]').innerText,
-    subtext: (el) => el.querySelector('[class^=sub]').innerText,
+    text: (el) => el.querySelector('[class^=text]').textContent,
+    subtext: (el) => el.querySelector('[class^=sub]').textContent,
     visible: isVisible,
     proximity: {
       apply: (el) => el.getAttribute('data-test-tooltip-proximity-element') === 'true',
@@ -19,8 +19,8 @@ export const Tooltip = createInteractor('tooltip')
 export const TooltipProximity = createInteractor('tooltip proximity element')
   .selector('[role^=tooltip]')
   .locator([
-    (el) => el.querySelector('[class^=text]').innerText,
+    (el) => el.querySelector('[class^=text]').textContent,
   ])
   .filters({
-    text: (el) => el.querySelector('[class^=text]').innerText,
+    text: (el) => el.querySelector('[class^=text]').textContent,
   });


### PR DESCRIPTION
For all intents and purposes, `innerText` seemed like the better option and broke nothing in test suites running in actual browsers...
but..

These interactors have to run in JSDOM (rtl/jest) as well, and JSDOM doesn't emulate innerText, so all references to innerText come back as `undefined`



