### PR TITLE
Export dispatchFocusout from util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Implement e-2-e automation of test case C4059. Refs FAT-810.
 * Implement e-2-e automation of test case C4061. Refs FAT-807.
+* Export `dispatchFocusout` from `util` so that other Interactors can make use of it. Refs STSMACOM-541.
 
 ## [4.0.0](https://github.com/folio-org/stripes-testing/tree/v4.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v3.0.0...v4.0.0)

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -35,3 +35,4 @@ export { default as Selection, SelectionList, SelectionOption } from './selectio
 export { default as TextField } from './text-field';
 export { default as TextArea } from './textarea';
 export { Tooltip, TooltipProximity } from './tooltip';
+export { dispatchFocusout } from './util'

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -35,4 +35,4 @@ export { default as Selection, SelectionList, SelectionOption } from './selectio
 export { default as TextField } from './text-field';
 export { default as TextArea } from './textarea';
 export { Tooltip, TooltipProximity } from './tooltip';
-export { dispatchFocusout } from './util'
+export { dispatchFocusout } from './util';


### PR DESCRIPTION
- Export `dispatchFocusout` from `util` so that other Interactors can make use of it. Refs [STSMACOM-541](https://issues.folio.org/browse/STSMACOM-541).