### PR TITLE
Upgrade interactors to 1.0.0 rc1

### DIFF
--- a/interactors/keyboard.js
+++ b/interactors/keyboard.js
@@ -51,7 +51,7 @@ export default createInteractor('keyboard (requires window to have focus)')
     altLeft: press('AltLeft'),
     tab: press('Tab'),
     space: press('Space'),
-    pressKey: (value) => press(value),
+    pressKey: (interactor, value, options) => press(value)(interactor, options)
   })();
 
 const KEY_CODES = {

--- a/interactors/layer.js
+++ b/interactors/layer.js
@@ -1,7 +1,7 @@
-import { createInteractor, focused } from '@interactors/html';
+import { HTML } from '@interactors/html';
 import { isVisible } from 'element-is-visible';
 
-export default createInteractor('layer')
+export default HTML.extend('layer')
   .selector('[class^=LayerRoot]')
   .locator((el) => el.ariaLabel)
   .filters({
@@ -9,6 +9,5 @@ export default createInteractor('layer')
     visible: {
       apply: (el) => isVisible(el) || (el.labels && Array.from(el.labels).some(isVisible)),
       default: true
-    },
-    focused
+    }
   });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json "
   },
   "dependencies": {
-    "@interactors/html": "^0.33.0",
+    "@interactors/html": "^1.0.0-rc1.0",
     "axe-core": "4.3.3",
     "date-fns": "^2.16.1",
     "debug": "^4.0.1",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.3",
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@interactors/with-cypress": "^0.1.3",
+    "@interactors/with-cypress": "^1.0.0-rc1.0",
     "babel-eslint": "^10.1.0",
     "bigtest": "^0.14.0",
     "cypress": "^9.0.0",


### PR DESCRIPTION
`@interactors/html` is prepping for the 1.0 release. This will make sure that we don't break anything before then.

