### PR TITLE
FAT-1090: Setup cypress-grep plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Export `dispatchFocusout` from `util` so that other Interactors can make use of it. Refs STSMACOM-541.
 * Add `AddressEdit, AddressList` interactors. Refs STSMACOM-608.
 * Implement e-2-e automation of test case C11112. Refs FAT-758.
+* Add `cypress-grep` plugin to be able to run tests by tags. Refs FAT-1090.
 
 ## [4.0.0](https://github.com/folio-org/stripes-testing/tree/v4.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v3.0.0...v4.0.0)

--- a/cypress/integration/notes/notes.spec.js
+++ b/cypress/integration/notes/notes.spec.js
@@ -27,7 +27,7 @@ describe('Note creation', () => {
     Agreements.selectRecord();
     AgreementDetails.openNotesSection();
   });
-  it('C1296 Create a note', () => {
+  it('C1296 Create a note', { tags: '@smoke' }, () => {
     AgreementDetails.createNote(longNote);
     Agreements.selectRecord();
     AgreementDetails.waitLoadingWithExistingNote(longNote.title);

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,8 +1,11 @@
 const globby = require('globby');
 const { rmdir, unlink } = require('fs');
+const cypressGrep = require('cypress-grep/src/plugin');
 
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
+  cypressGrep(config);
+
   on('task', {
     // a task to find files matching the given mask
     async findFiles(mask) {
@@ -45,4 +48,6 @@ module.exports = (on, config) => {
       });
     }
   });
+
+  return config;
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,6 +21,7 @@ setInteractorTimeout(20_000);
 
 
 require('cypress-xpath');
+require('cypress-grep')();
 
 // try to fix the issue with cached location in cypress
 Cypress.on('window:before:load', window => {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bigtest": "^0.14.0",
     "cypress": "^9.1.1",
     "cypress-file-upload": "^5.0.8",
+    "cypress-grep": "^2.12.0",
     "cypress-xpath": "^1.6.2",
     "eslint": "^7.15.0",
     "eslint-plugin-cypress": "^2.11.2",


### PR DESCRIPTION
## Description
Setup `cypress-grep` plugin. It gives the ability to filter and run tests by tags, name, etc.
https://github.com/cypress-io/cypress-grep

## Issues
[FAT-1090](https://issues.folio.org/browse/FAT-1090)