### PR TITLE
UITEST-86 Export mocha

### DIFF
--- a/mocha/index.js
+++ b/mocha/index.js
@@ -1,0 +1,1 @@
+export * from 'mocha';

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "date-fns": "^2.16.1",
     "debug": "^4.0.1",
     "element-is-visible": "^1.0.0",
+    "mocha": "^9.0.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
There's a variety of mocha version dependencies between all of the modules - from 5.x.x to 9.x.x - this PR aims to centralize that dependency so that it can be imported from a single place.

If tests still import mocha from `@bigtest/mocha`, the import can remain as is...

however, if tests import mocha directly, the export path will need to be changed:
```
import { beforeEach, describe, it } from 'mocha';
```
to
```
import { beforeEach, describe, it } from '@folio/stripes-testing/mocha';
```

the `mocha` entry can be removed from that module's `package.json`
and, of course, add  `@folio/stripes-testing: "^4.2.0"` as a devDependency if it isn't already included.