### PR TITLE
UITEST-89 Added AdvancedSearch interactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Implement e-2-e automation of test case C11112. Refs FAT-758.
 * Add `cypress-grep` plugin to be able to run tests by tags. Refs FAT-1090.
 * Implement e-2-e automation of test case C11113. Refs FAT-759.
+* Add `AdvancedSearch` interactor. Refs UITEST-89.
 
 ## [4.0.0](https://github.com/folio-org/stripes-testing/tree/v4.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v3.0.0...v4.0.0)

--- a/interactors/advanced-search.js
+++ b/interactors/advanced-search.js
@@ -1,0 +1,33 @@
+import Button from './button';
+import Select from './select';
+import TextField from './text-field';
+import HTML from './baseHTML';
+
+export const AdvancedSearchRow = HTML.extend('advanced search row')
+  .selector('[class*=AdvancedSearchRow-]')
+  .filters({
+    index: el => parseInt(el.getAttribute('data-row-index'), 10),
+    query: el => el.querySelector('input').getAttribute('value'),
+    bool: el => el.querySelectorAll('select')[0].value,
+    option: el => el.querySelectorAll('select')[1].value,
+  })
+  .actions({
+    fillQuery: ({ find }, value) => find(TextField({ label: 'Search for' })).fillIn(value),
+    selectBoolean: ({ find }, rowIndex, value) => find(Select({ id: `advanced-search-bool-${rowIndex}` }))
+      .choose(value),
+    selectSearchOption: ({ find }, value) => find(Select({ ariaLabel: 'Search options' })).choose(value),
+  });
+
+const rows = el => [...el.querySelectorAll('[class*=AdvancedSearchRow-]')];
+
+export const AdvancedSearch = HTML.extend('advanced search')
+  .selector('[id=advanced-search-modal]')
+  .filters({
+    rows,
+    id: (el) => el.getAttribute('id'),
+    rowCount: el => rows(el).length,
+  })
+  .actions({
+    cancel: ({ find }) => find(Button('Cancel')).click(),
+    search: ({ find }) => find(Button('Search')).click(),
+  });

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -41,6 +41,7 @@ export { dispatchFocusout } from './util';
 export { default as QuickMarcEditorRow } from './quickMarcEditorRow';
 export { default as QuickMarcEditor } from './quickMarcEditor';
 export { default as Section } from './section';
+export { AdvancedSearch, AdvancedSearchRow } from './advanced-search';
 
 // Stripes-smart-component interactors
 export { AddressList, AddressEdit, AddressItem } from './address-edit-list';

--- a/interactors/select.js
+++ b/interactors/select.js
@@ -19,6 +19,7 @@ export default HTML.extend('select')
     id: el => el.querySelector('select').id,
     name: el => el.querySelector('select').name,
     label,
+    ariaLabel: el => el.querySelector('select').getAttribute('aria-label'),
     ariaLabelledBy: el => el.querySelector('select').getAttribute('aria-labelledby'),
     placeholder: el => el.querySelector('select').getAttribute('placeholder'),
     value: el => el.querySelector('select').value,


### PR DESCRIPTION
## Description
Adding interactor for new `<AdvancedSearch>` component

## Issues
[UITEST-89](https://issues.folio.org/browse/UITEST-89)

## Related PRs
https://github.com/folio-org/stripes-components/pull/1706
https://github.com/folio-org/ui-marc-authorities/pull/57