### PR TITLE
UITEST-93: Fix AdvancedSearch search option select interactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-testing
 
+## [4.3.0](IN PROGRESS)
+
+* Fix AdvancedSearch search option select interactor. Refs UITEST-89.
+
 ## [4.2.0](https://github.com/folio-org/stripes-testing/tree/v4.2.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v4.0.0...v4.2.0)
 

--- a/interactors/advanced-search.js
+++ b/interactors/advanced-search.js
@@ -15,7 +15,7 @@ export const AdvancedSearchRow = HTML.extend('advanced search row')
     fillQuery: ({ find }, value) => find(TextField({ label: 'Search for' })).fillIn(value),
     selectBoolean: ({ find }, rowIndex, value) => find(Select({ id: `advanced-search-bool-${rowIndex}` }))
       .choose(value),
-    selectSearchOption: ({ find }, value) => find(Select({ ariaLabel: 'Search options' })).choose(value),
+    selectSearchOption: ({ find }, rowIndex, value) => find(Select({ id: `advanced-search-option-${rowIndex}` })).choose(value),
   });
 
 const rows = el => [...el.querySelectorAll('[class*=AdvancedSearchRow-]')];


### PR DESCRIPTION
## Description
`<Select>` doesn't add `aria-label` attribute to `select` html element. We need to use `id` attribute instead to find the component

## Issues
[UITEST-93](https://issues.folio.org/browse/UITEST-93)