### PR TITLE
FAT-823-FIX: Roll back to old open() in inventoryActions

### DIFF
--- a/cypress/integration/inventory/create-fast-add-record.spec.js
+++ b/cypress/integration/inventory/create-fast-add-record.spec.js
@@ -45,7 +45,6 @@ describe('ui-inventory: Create fast add record', () => {
   });
 
   it('C15850 Create a fast add record from Inventory. Monograph.', { tags: [TestTypes.smoke] }, () => {
-    InventoryActions.open();
     InventoryActions.openNewFastAddRecordForm();
     FastAddNewRecord.waitLoading();
     FastAddNewRecord.fillFastAddNewRecordForm(FastAddNewRecord.fastAddNewRecordFormDetails);

--- a/cypress/support/fragments/inventory/inventoryActions.js
+++ b/cypress/support/fragments/inventory/inventoryActions.js
@@ -10,7 +10,7 @@ const importTypeSelect = Select({ name :'externalIdentifierType' });
 
 // TODO: merge inventoryActions and InventoryInstances
 export default {
-  open: () => cy.do(Section({ id:'pane-results' }).find(Button('Actions')).click()),
+  open: () => Section({ id:'pane-results' }).find(Button('Actions')).click(),
   options: {
     new: Button('New'),
     saveUUIDs: Button('Save instances UUIDs'),
@@ -20,7 +20,12 @@ export default {
     newRequest: Button('New Request'),
     newFastAddRecord: Button('New Fast Add Record'),
   },
-  openNewFastAddRecordForm() { cy.do(this.options.newFastAddRecord.click()); },
+  openNewFastAddRecordForm() {
+    cy.do([
+      this.open(),
+      this.options.newFastAddRecord.click()
+    ]);
+  },
   optionsIsDisabled: (array) => {
     return array.forEach((element) => {
       cy.expect(element.is({ disabled: true }));


### PR DESCRIPTION
## Purpose
- Small change to roll back to old version of `open()` method in `inventoryActions` not break other tests.