### PR TITLE
Add ConfirmationModal interactor

### DIFF
--- a/interactors/confirmation-modal.js
+++ b/interactors/confirmation-modal.js
@@ -1,0 +1,9 @@
+import { including } from '@interactors/html';
+import Button from './button';
+import Modal from './modal';
+
+export default Modal.extend('confirmation modal')
+  .actions({
+    confirm: ({ find }, label = 'Confirm') => find(Button(including(label))).click(),
+    cancel: ({ find }, label = 'Cancel') => find(Button(including(label))).click(),
+  });

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -51,6 +51,7 @@ export { default as QuickMarcEditorRow } from './quickMarcEditorRow';
 export { default as QuickMarcEditor } from './quickMarcEditor';
 export { AdvancedSearch, AdvancedSearchRow } from './advanced-search';
 export { FieldSet, FieldInFieldset } from './fieldset';
+export { default as ConfirmationModal } from './confirmation-modal';
 
 // Stripes-smart-component interactors
 export { AddressList, AddressEdit, AddressItem } from './address-edit-list';


### PR DESCRIPTION
Created while marching through stripes-components, working to phase out the bigtest-pre-alpha interactors. Seems like it might be handy for E2E tests to use.