### PR TITLE
Revert "C359237 Verify "Expiration date" option in the dropdown"

### DIFF
--- a/cypress/e2e/bulk-edit/in-app/bulk-edit-in-app-users.cy.js
+++ b/cypress/e2e/bulk-edit/in-app/bulk-edit-in-app-users.cy.js
@@ -126,16 +126,5 @@ describe('bulk-edit', () => {
       UsersSearchPane.openUser(user.username);
       UsersCard.verifyExpirationDate(todayDate);
     });
-
-    it('C359237 Verify "Expiration date" option in the dropdown (firebird)', { tags: [testTypes.smoke, devTeams.firebird] }, () => {
-      BulkEditSearchPane.selectRecordIdentifier('User UUIDs');
-
-      BulkEditSearchPane.uploadFile(userUUIDsFileName);
-      BulkEditSearchPane.waitFileUploading();
-
-      BulkEditActions.openActions();
-      BulkEditActions.openInAppStartBulkEditFrom();
-      BulkEditActions.verifyCalendarItem();
-    });
   });
 });

--- a/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
+++ b/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
@@ -8,7 +8,7 @@ import {
   Checkbox,
   MultiColumnListHeader,
   MultiColumnListCell,
-  TextField, Datepicker
+  TextField
 } from '../../../../interactors';
 
 const actionsBtn = Button('Actions');
@@ -118,12 +118,6 @@ export default {
       Button({ icon: 'calendar' }).click(),
       TextField().fillIn(date)
     ]);
-  },
-
-  verifyCalendarItem() {
-    getBulkEditSelectType().select('Expiration date');
-    cy.do(Button({ icon: 'calendar' }).click());
-    cy.expect(Datepicker().exists());
   },
 
   fillLoanType(type = 'Selected') {

--- a/cypress/support/fragments/users/usersCard.js
+++ b/cypress/support/fragments/users/usersCard.js
@@ -185,9 +185,6 @@ export default {
 
   verifyExpirationDate(date) {
     // date format MM/DD/YYYY
-    const expectedDate = date.split('/');
-    expectedDate[0] = expectedDate[0].replace('0', '');
-    expectedDate[1] = expectedDate[1].replace('0', '');
-    cy.expect(KeyValue('Expiration date').has({ value: including(expectedDate.join('/')) }));
+    cy.expect(KeyValue('Expiration date').has({ value: including(date) }));
   },
 };

--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -6,7 +6,7 @@ import { dispatchFocusout } from './util';
 import HTML from './baseHTML';
 
 export default HTML.extend('datepicker')
-  .selector('[data-test-datepicker-container],[id^=datepicker-calendar-container]')
+  .selector('[data-test-datepicker-container]')
   .locator((el) => el.querySelector('label').textContent)
   .filters({
     id: (el) => el.querySelector('input').id,


### PR DESCRIPTION
Reverts folio-org/stripes-testing#712

Changes to the datepicker interactor break existing tests within stripes components. The expanded selector is causing the following error when the Calendar of the datepicker is open:

```
AmbiguousElementError: datepicker matches multiple elements:
        
        - <div class="container---2BEIC" data-test-datepicker-container="true">
        - <div role="application" aria-roledescription="datepicker" aria-label="calendar" class="calendar---3Cw1O maxWidth---TdFVf" id="datepicker-calendar-container-dp-750" tabindex="-1" data-test-calendar="true">
```

The Calendar pop-up from Datepicker has its own `Calendar` interactor that can be used to check for the existence of the Calendar, if necessary.
