### PR TITLE
Remove extra selector from datepicker interactor

### DIFF
--- a/interactors/datepicker.js
+++ b/interactors/datepicker.js
@@ -6,7 +6,7 @@ import { dispatchFocusout } from './util';
 import HTML from './baseHTML';
 
 export default HTML.extend('datepicker')
-  .selector('[data-test-datepicker-container],[id^=datepicker-calendar-container]')
+  .selector('[data-test-datepicker-container]')
   .locator((el) => el.querySelector('label').textContent)
   .filters({
     id: (el) => el.querySelector('input').id,


### PR DESCRIPTION
https://github.com/folio-org/stripes-testing/pull/715 may be too harsh a reversion since it removes the added tests. This PR only removes the extended selector for the Datepicker interactor.