### PR TITLE
UITEST-106: update MultiColumnList interactor actions for pagination buttons

### DIFF
--- a/interactors/multi-column-list.js
+++ b/interactors/multi-column-list.js
@@ -81,14 +81,14 @@ export const MultiColumnList = HTML.extend('multi column list')
       const contentSearch = !column ? { columnIndex: 0 } : { content: column };
       return interactor.find(MultiColumnListCell({ row, ...contentSearch })).click();
     },
-    clickNextPagingButton: (interactor, label = 'Next') => {
-      return interactor.find(Button(label)).click();
+    clickNextPagingButton: (interactor, label = 'next') => {
+      return interactor.perform((el) => el.parentNode.querySelector(`[data-button-id=${label}]`).click());
     },
-    clickPreviousPagingButton: (interactor, label = 'Previous') => {
-      return interactor.find(Button(label)).click();
+    clickPreviousPagingButton: (interactor, label = 'previous') => {
+      return interactor.perform((el) => el.parentNode.querySelector(`[data-button-id=${label}]`).click());
     },
-    clickLoadMoreButton: (interactor, label = 'Load more') => {
-      return interactor.find(Button(label)).click();
+    clickLoadMoreButton: (interactor, label = 'load-more') => {
+      return interactor.perform((el) => el.parentNode.querySelector(`[data-button-id=${label}]`).click());
     }
   });
 


### PR DESCRIPTION
MultiColumnList's pagination was previously rendered within the element's primary container. This caused accessibility tests to report issues.
[The PR in stripes components](https://github.com/folio-org/stripes-components/pull/1993) moves the pagination outside of the container. This PR updates those actions to cover the case. It's possible, with such specific actions, that the `Button` interactor may just have to be used for tests instead.