### PR TITLE
bump minor for new development work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-testing",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Regression tests for FOLIO UI",
   "repository": "folio-org/stripes-testing",
   "publishConfig": {


### PR DESCRIPTION
This should have been done as soon as 4.5.0, e970c50f1d8c226d8073788f91a6a4d89fb4bdc5, was tagged so all new tests and new features were merged onto the next version. 