### PR TITLE
FAT-8202/C407662

### DIFF
--- a/cypress/e2e/users/edit-users.cy.js
+++ b/cypress/e2e/users/edit-users.cy.js
@@ -31,11 +31,14 @@ describe('Permissions Tags', () => {
       ).then((userProperties) => {
         userData = userProperties;
         UserEdit.addServicePointViaApi(servicePointId, userData.userId, servicePointId);
-        cy.login(userData.username, userData.password, {
-          path: TopMenu.usersPath,
-          waiter: UsersSearchPane.waitLoading,
-        });
       });
+    });
+  });
+
+  beforeEach('Login', () => {
+    cy.login(userData.username, userData.password, {
+      path: TopMenu.usersPath,
+      waiter: UsersSearchPane.waitLoading,
     });
   });
 
@@ -53,6 +56,24 @@ describe('Permissions Tags', () => {
       UserEdit.changeMiddleName(newMiddleName);
       UserEdit.saveAndClose();
       Users.verifyMiddleNameOnUserDetailsPane(newMiddleName);
+    },
+  );
+
+  it(
+    'C407662 "User search results" pane results remain after canceling user\'s profile editing (volaris)',
+    { tags: [TestTypes.extendedPath, devTeams.volaris] },
+    () => {
+      userData.middleName = newMiddleName;
+      UsersSearchPane.searchByUsername(userData.username);
+      UserEdit.openEdit();
+      UserEdit.verifySaveAndColseIsDisabled(true);
+      UserEdit.changeMiddleName(getTestEntityValue('newName'));
+      UserEdit.verifySaveAndColseIsDisabled(false);
+      UserEdit.cancelChanges();
+      Users.verifyMiddleNameOnUserDetailsPane(userData.middleName);
+      Users.verifyFullNameIsDisplayedCorrectly(
+        `${userData.lastName}, ${userData.firstName} ${userData.middleName}`,
+      );
     },
   );
 });

--- a/cypress/support/fragments/users/userEdit.js
+++ b/cypress/support/fragments/users/userEdit.js
@@ -99,6 +99,14 @@ export default {
     cy.do(Modal().find(saveAndCloseBtn).click());
   },
 
+  verifySaveAndColseIsDisabled: (status) => {
+    cy.expect(saveAndCloseBtn.has({ disabled: status }));
+  },
+
+  cancelChanges() {
+    cy.do([Button('Cancel').click(), Button('Close without saving').click()]);
+  },
+
   saveAndClose() {
     cy.do(saveAndCloseBtn.click());
   },


### PR DESCRIPTION
- [FAT-8202](https://issues.folio.org/browse/FAT-8202)
- ["User search results" pane results remain after canceling user's profile editing](https://foliotest.testrail.io/index.php?/cases/view/407662)
- [Allure](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/4403/allure/#suites/60aef4739493073e65c5d706506f5371/6d02b41e9f622bfb/)