### PR TITLE
UITEST-110 Update interactors for changes to MCL markup

### DIFF
--- a/interactors/multi-column-list.js
+++ b/interactors/multi-column-list.js
@@ -69,7 +69,7 @@ export const MultiColumnList = HTML.extend('multi column list')
   .locator((el) => el.id)
   .filters({
     columns,
-    id: (el) => el.id,
+    id: (el) => el.querySelector('[role=grid]').id,
     columnCount: (el) => columns(el).length,
     rowCount: (el) => el.querySelectorAll('[class*=mclRow-]').length,
     height: (el) => el.offsetHeight,
@@ -79,7 +79,7 @@ export const MultiColumnList = HTML.extend('multi column list')
       (d) => !!d.querySelector('[data-test-clickable-header]'),
     ),
     visible: (el) => isVisible(el),
-    ariaRowCount: (el) => +el.getAttribute('aria-rowcount'),
+    ariaRowCount: (el) => el.querySelector('[role=grid]').getAttribute('aria-rowcount'),
   })
   .actions({
     clickHeader: (interactor, header) => interactor.find(MultiColumnListHeader(header)).click(),


### PR DESCRIPTION
[Changes to MCL in stripes components changed mark-up](https://github.com/folio-org/stripes-components/pull/2125). Typically, filters from interactors would need to be adjusted up front, but in this case problematic filters were not being used by tests in stripes-components, so the typical flow of usage/updates didn't run into issues. 
I have a PR for stripes-components to add tests that make use of the filters, and I've pointed it at this branch: https://github.com/folio-org/stripes-components/pull/2129