### PR TITLE
C377031 A user can view Acquisition Methods in Order field mapping with "Settings (Data import): Can view, create, edit, and remove" (folijet) (TaaS)

### DIFF
--- a/cypress/e2e/data-import/permissions/can-view-acquisition-methods-in-order-field-mapping.cy.js
+++ b/cypress/e2e/data-import/permissions/can-view-acquisition-methods-in-order-field-mapping.cy.js
@@ -1,0 +1,36 @@
+import { DevTeams, Permissions, TestTypes } from '../../../support/dictionary';
+import SettingsPane from '../../../support/fragments/settings/settingsPane';
+import NewFieldMappingProfile from '../../../support/fragments/data_import/mapping_profiles/newFieldMappingProfile';
+import FieldMappingProfiles from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfiles';
+import SettingsMenu from '../../../support/fragments/settingsMenu';
+import Users from '../../../support/fragments/users/users';
+import { FOLIO_RECORD_TYPE } from '../../../support/constants';
+
+describe('Permissions', () => {
+  let user;
+  before('create test data', () => {
+    cy.createTempUser([Permissions.settingsDataImportEnabled.gui]).then((userProperties) => {
+      user = userProperties;
+      cy.login(user.username, user.password, {
+        path: SettingsMenu.mappingProfilePath,
+        waiter: SettingsPane.waitLoading,
+      });
+    });
+  });
+
+  after('delete test data', () => {
+    Users.deleteViaApi(user.userId);
+  });
+
+  it(
+    'C377031 A user can view Acquisition Methods in Order field mapping with "Settings (Data import): Can view, create, edit, and remove" (folijet) (TaaS)',
+    { tags: [TestTypes.extendedPath, DevTeams.folijet] },
+    () => {
+      FieldMappingProfiles.openNewMappingProfileForm();
+      NewFieldMappingProfile.waitLoading();
+      NewFieldMappingProfile.addIncomingRecordType(FOLIO_RECORD_TYPE.MARCBIBLIOGRAPHIC);
+      NewFieldMappingProfile.addFolioRecordType(FOLIO_RECORD_TYPE.ORDER);
+      NewFieldMappingProfile.acquisitionMethodsDropdownListIsVisible();
+    },
+  );
+});

--- a/cypress/e2e/data-import/permissions/can-view-acquisition-methods-in-order-field-mapping.cy.js
+++ b/cypress/e2e/data-import/permissions/can-view-acquisition-methods-in-order-field-mapping.cy.js
@@ -6,31 +6,33 @@ import SettingsMenu from '../../../support/fragments/settingsMenu';
 import Users from '../../../support/fragments/users/users';
 import { FOLIO_RECORD_TYPE } from '../../../support/constants';
 
-describe('Permissions', () => {
-  let user;
-  before('create test data', () => {
-    cy.createTempUser([Permissions.settingsDataImportEnabled.gui]).then((userProperties) => {
-      user = userProperties;
-      cy.login(user.username, user.password, {
-        path: SettingsMenu.mappingProfilePath,
-        waiter: SettingsPane.waitLoading,
+describe('data-import', () => {
+  describe('Permissions', () => {
+    let user;
+    before('create test data', () => {
+      cy.createTempUser([Permissions.settingsDataImportEnabled.gui]).then((userProperties) => {
+        user = userProperties;
+        cy.login(user.username, user.password, {
+          path: SettingsMenu.mappingProfilePath,
+          waiter: SettingsPane.waitLoading,
+        });
       });
     });
-  });
 
-  after('delete test data', () => {
-    Users.deleteViaApi(user.userId);
-  });
+    after('delete test data', () => {
+      Users.deleteViaApi(user.userId);
+    });
 
-  it(
-    'C377031 A user can view Acquisition Methods in Order field mapping with "Settings (Data import): Can view, create, edit, and remove" (folijet) (TaaS)',
-    { tags: [TestTypes.extendedPath, DevTeams.folijet] },
-    () => {
-      FieldMappingProfiles.openNewMappingProfileForm();
-      NewFieldMappingProfile.waitLoading();
-      NewFieldMappingProfile.addIncomingRecordType(FOLIO_RECORD_TYPE.MARCBIBLIOGRAPHIC);
-      NewFieldMappingProfile.addFolioRecordType(FOLIO_RECORD_TYPE.ORDER);
-      NewFieldMappingProfile.acquisitionMethodsDropdownListIsVisible();
-    },
-  );
+    it(
+      'C377031 A user can view Acquisition Methods in Order field mapping with "Settings (Data import): Can view, create, edit, and remove" (folijet) (TaaS)',
+      { tags: [TestTypes.extendedPath, DevTeams.folijet] },
+      () => {
+        FieldMappingProfiles.openNewMappingProfileForm();
+        NewFieldMappingProfile.waitLoading();
+        NewFieldMappingProfile.addIncomingRecordType(FOLIO_RECORD_TYPE.MARCBIBLIOGRAPHIC);
+        NewFieldMappingProfile.addFolioRecordType(FOLIO_RECORD_TYPE.ORDER);
+        NewFieldMappingProfile.acquisitionMethodsDropdownListIsVisible();
+      },
+    );
+  });
 });

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -172,10 +172,10 @@ export const RECEIVING_WORKFLOW_NAMES = {
 };
 
 export const ACQUISITION_METHOD_NAMES = {
-  APPROVAL_PLAN: 'Approval plan',
-  DDA: 'Demand driven acquisitions (DDA)',
+  APPROVAL_PLAN: 'Approval Plan',
+  DDA: 'Demand Driven Acquisitions (DDA)',
   DEPOSITORY: 'Depository',
-  EBA: 'Evidence based acquisitions (EBA)',
+  EBA: 'Evidence Based Acquisitions (EBA)',
   EXCHANGE: 'Exchange',
   FREE: 'Free',
   GIFT: 'Gift',

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -172,10 +172,10 @@ export const RECEIVING_WORKFLOW_NAMES = {
 };
 
 export const ACQUISITION_METHOD_NAMES = {
-  APPROVAL_PLAN: 'Approval Plan',
-  DDA: 'Demand Driven Acquisitions (DDA)',
+  APPROVAL_PLAN: 'Approval plan',
+  DDA: 'Demand driven acquisitions (DDA)',
   DEPOSITORY: 'Depository',
-  EBA: 'Evidence Based Acquisitions (EBA)',
+  EBA: 'Evidence based acquisitions (EBA)',
   EXCHANGE: 'Exchange',
   FREE: 'Free',
   GIFT: 'Gift',
@@ -260,4 +260,20 @@ export const VENDOR_NAMES = {
 export const HOLDINGS_TYPE_NAMES = {
   ELECTRONIC: 'Electronic',
   MONOGRAPH: 'Monograph',
+};
+
+export const ACQUISITION_METHOD_NAMES_IN_MAPPING_PROFILES = {
+  APPROVAL_PLAN: 'Approval Plan',
+  DDA: 'Demand Driven Acquisitions (DDA)',
+  DEPOSITORY: 'Depository',
+  EBA: 'Evidence Based Acquisitions (EBA)',
+  EXCHANGE: 'Exchange',
+  FREE: 'Free',
+  GIFT: 'Gift',
+  INTERNAL_TRANSFER: 'Internal transfer',
+  MEMBERSHIP: 'Membership',
+  OTHER: 'Other',
+  PURCHASE: 'Purchase',
+  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase At Vendor System',
+  TECHNICAL: 'Technical',
 };

--- a/cypress/support/fragments/data_import/mapping_profiles/newFieldMappingProfile.js
+++ b/cypress/support/fragments/data_import/mapping_profiles/newFieldMappingProfile.js
@@ -20,7 +20,7 @@ import {
   FOLIO_RECORD_TYPE,
   INSTANCE_STATUS_TERM_NAMES,
   EXISTING_RECORDS_NAMES,
-  ACQUISITION_METHOD_NAMES,
+  ACQUISITION_METHOD_NAMES_IN_MAPPING_PROFILES,
 } from '../../../constants';
 
 const saveButton = Button('Save as profile & Close');
@@ -985,7 +985,7 @@ export default {
       text: including('Acquisition method'),
     });
     cy.do(acquisitionMethodSection.find(Dropdown()).open());
-    Object.values(ACQUISITION_METHOD_NAMES).forEach((method) => {
+    Object.values(ACQUISITION_METHOD_NAMES_IN_MAPPING_PROFILES).forEach((method) => {
       cy.expect(DropdownMenu().find(Button(method)).exists());
     });
   },

--- a/cypress/support/fragments/data_import/mapping_profiles/newFieldMappingProfile.js
+++ b/cypress/support/fragments/data_import/mapping_profiles/newFieldMappingProfile.js
@@ -12,12 +12,15 @@ import {
   SearchField,
   Accordion,
   Checkbox,
+  Dropdown,
+  DropdownMenu,
 } from '../../../../../interactors';
 import getRandomPostfix from '../../../utils/stringTools';
 import {
   FOLIO_RECORD_TYPE,
   INSTANCE_STATUS_TERM_NAMES,
   EXISTING_RECORDS_NAMES,
+  ACQUISITION_METHOD_NAMES,
 } from '../../../constants';
 
 const saveButton = Button('Save as profile & Close');
@@ -974,5 +977,16 @@ export default {
       .then(({ response }) => {
         return response;
       });
+  },
+
+  acquisitionMethodsDropdownListIsVisible: () => {
+    const acquisitionMethodSection = HTML({
+      className: including('col-'),
+      text: including('Acquisition method'),
+    });
+    cy.do(acquisitionMethodSection.find(Dropdown()).open());
+    Object.values(ACQUISITION_METHOD_NAMES).forEach((method) => {
+      cy.expect(DropdownMenu().find(Button(method)).exists());
+    });
   },
 };


### PR DESCRIPTION
[C377031](https://foliotest.testrail.io/index.php?/cases/view/377031 )

[report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/4507/allure/)