### PR TITLE
[402353] Holdings records creation when open order Electronic resource (thunderjet) (TaaS)

### DIFF
--- a/cypress/e2e/orders/holdings-records creation-for-order-with-electronic-resource-format.cy.js
+++ b/cypress/e2e/orders/holdings-records creation-for-order-with-electronic-resource-format.cy.js
@@ -38,20 +38,23 @@ describe('Orders', () => {
             testData.orderLine = {
               ...BasicOrderLine.getDefaultOrderLine(),
               cost: {
-                listUnitPrice: 10,
+                listUnitPriceElectronic: 10,
                 currency: 'USD',
                 discountType: 'percentage',
-                quantityPhysical: 2,
+                quantityElectronic: 2,
               },
-              orderFormat: 'Physical Resource',
+              orderFormat: 'Electronic Resource',
               checkinItems: CHECKIN_ITEMS_VALUE[RECEIVING_WORKFLOWS.INDEPENDENT],
-              physical: {
+              eresource: {
+                activated: false,
                 createInventory: 'Instance, Holding, Item',
+                trial: false,
+                accessProvider: testData.organization.id,
                 materialType: materialTypeId,
               },
               locations: [
-                { locationId: testData.locations[0].id, quantityPhysical: 1 },
-                { locationId: testData.locations[1].id, quantityPhysical: 1 },
+                { locationId: testData.locations[0].id, quantity: 1, quantityElectronic: 1 },
+                { locationId: testData.locations[1].id, quantity: 1, quantityElectronic: 1 },
               ],
             };
 
@@ -91,7 +94,7 @@ describe('Orders', () => {
   });
 
   it(
-    'C402352 Holdings records creation when open order with "Physical Resource" format PO line and Independent workflow (thunderjet) (TaaS)',
+    'C402353 Holdings records creation when open order with "Electronic Resource" format PO line and Independent workflow (thunderjet) (TaaS)',
     { tags: [TestTypes.criticalPath, DevTeams.thunderjet] },
     () => {
       // Open Order
@@ -108,11 +111,11 @@ describe('Orders', () => {
         locations: [
           [
             { key: 'Holding', value: testData.locations[0].name },
-            { key: 'Quantity physical', value: 1 },
+            { key: 'Quantity electronic', value: 1 },
           ],
           [
             { key: 'Holding', value: testData.locations[1].name },
-            { key: 'Quantity physical', value: 1 },
+            { key: 'Quantity electronic', value: 1 },
           ],
         ],
       });

--- a/cypress/support/fragments/orders/basicOrderLine.js
+++ b/cypress/support/fragments/orders/basicOrderLine.js
@@ -6,6 +6,10 @@ export const RECEIVING_WORKFLOWS = {
   SYNCHRONIZED: 'Synchronized order and receipt quantity',
   INDEPENDENT: 'Independent order and receipt quantity',
 };
+export const CHECKIN_ITEMS_VALUE = {
+  [RECEIVING_WORKFLOWS.SYNCHRONIZED]: false,
+  [RECEIVING_WORKFLOWS.INDEPENDENT]: true,
+};
 
 const getDefaultOrderLine = ({
   quantity = 1,


### PR DESCRIPTION
[C402353](https://foliotest.testrail.io/index.php?/cases/view/402353)
***
[Allure report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/4911/allure)
***

<img width="844" alt="Screenshot 2023-10-18 at 15 19 11" src="https://github.com/folio-org/stripes-testing/assets/16187978/61256390-2850-42c4-8361-59a0d2c90c97">