### PR TITLE
[407655] Open order when ledger has separate acquisition unit (thunderjet) (TaaS)

### DIFF
--- a/cypress/e2e/orders/open-order-when-ledger-has-separate-aq-unit.cy.js
+++ b/cypress/e2e/orders/open-order-when-ledger-has-separate-aq-unit.cy.js
@@ -1,0 +1,121 @@
+import { DevTeams, TestTypes, Permissions } from '../../support/dictionary';
+import AcquisitionUnits from '../../support/fragments/settings/acquisitionUnits/acquisitionUnits';
+import { Budgets } from '../../support/fragments/finance';
+import { NewOrder, BasicOrderLine, Orders } from '../../support/fragments/orders';
+import Organizations from '../../support/fragments/organizations/organizations';
+import NewOrganization from '../../support/fragments/organizations/newOrganization';
+import TopMenu from '../../support/fragments/topMenu';
+import Users from '../../support/fragments/users/users';
+import { ORDER_STATUSES } from '../../support/constants';
+
+describe('Orders', () => {
+  const organization = NewOrganization.getDefaultOrganization();
+  const testData = {
+    organization,
+    order: NewOrder.getDefaultOrder({ vendorId: organization.id }),
+    acqUnit: AcquisitionUnits.getDefaultAcquisitionUnit({ protectRead: true }),
+    user: {},
+  };
+
+  before('Create test data', () => {
+    cy.getAdminToken().then(() => {
+      AcquisitionUnits.createAcquisitionUnitViaApi(testData.acqUnit).then(() => {
+        const { fiscalYear, fund, budget } = Budgets.createBudgetWithFundLedgerAndFYViaApi({
+          ledger: { acqUnitIds: [testData.acqUnit.id] },
+          budget: { allocated: 100 },
+        });
+
+        testData.fiscalYear = fiscalYear;
+        testData.fund = fund;
+        testData.budget = budget;
+
+        Organizations.createOrganizationViaApi(testData.organization).then(() => {
+          testData.orderLine = BasicOrderLine.getDefaultOrderLine();
+
+          Orders.createOrderWithOrderLineViaApi(testData.order, testData.orderLine).then(
+            (order) => {
+              testData.order = order;
+            },
+          );
+        });
+      });
+    });
+
+    cy.createTempUser([
+      Permissions.uiFinanceViewFundAndBudget.gui,
+      Permissions.uiOrdersApprovePurchaseOrders.gui,
+      Permissions.uiOrdersEdit.gui,
+    ]).then((userProperties) => {
+      testData.user = userProperties;
+
+      cy.login(testData.user.username, testData.user.password, {
+        path: TopMenu.ordersPath,
+        waiter: Orders.waitLoading,
+      });
+    });
+  });
+
+  after('Delete test data', () => {
+    Organizations.deleteOrganizationViaApi(testData.organization.id);
+    Orders.deleteOrderViaApi(testData.order.id);
+    Budgets.deleteBudgetWithFundLedgerAndFYViaApi(testData.budget);
+    AcquisitionUnits.deleteAcquisitionUnitViaApi(testData.acqUnit.id);
+    Users.deleteViaApi(testData.user.userId);
+  });
+
+  it(
+    'C407655 Open order when ledger has separate acquisition unit (thunderjet) (TaaS)',
+    { tags: [TestTypes.criticalPath, DevTeams.thunderjet] },
+    () => {
+      // Open Order
+      const OrderDetails = Orders.selectOrderByPONumber(testData.order.poNumber);
+      OrderDetails.checkOrderStatus(ORDER_STATUSES.PENDING);
+
+      // Click PO line record in "PO lines" accordion
+      const OrderLineDetails = OrderDetails.openPolDetails(testData.orderLine.titleOrPackage);
+      OrderLineDetails.checkFundDistibutionTableContent();
+
+      // Click "Actions" button, Select "Edit" option
+      const OrderLineEditForm = OrderLineDetails.openOrderLineEditForm();
+      OrderLineEditForm.checkButtonsConditions([
+        { label: 'Cancel', conditions: { disabled: false } },
+        { label: 'Save & close', conditions: { disabled: true } },
+      ]);
+
+      // Click "Add fund distribution" button, Select "Fund A"
+      OrderLineEditForm.addFundDistribution();
+      OrderLineEditForm.selectFundDistribution(testData.fund.name);
+
+      // Click "Save & close" button
+      OrderLineEditForm.clickSaveButton();
+      OrderLineDetails.checkFundDistibutionTableContent([{ name: testData.fund.name }]);
+
+      // Click "Back to PO" arrow
+      OrderLineDetails.backToOrderDetails();
+      OrderDetails.checkOrderStatus(ORDER_STATUSES.PENDING);
+
+      // Click "Actions" button, Select "Open" option
+      OrderDetails.openOrder({ orderNumber: testData.order.poNumber });
+      OrderDetails.checkOrderStatus(ORDER_STATUSES.OPEN);
+
+      // Click PO line record in "PO lines" accordion
+      OrderDetails.openPolDetails(testData.orderLine.titleOrPackage);
+      OrderLineDetails.checkFundDistibutionTableContent([{ name: testData.fund.name }]);
+
+      // Click "Current encumbrance" link in "Fund distribution" accordion
+      const TransactionDetails = OrderLineDetails.openEncumbrancePane();
+      TransactionDetails.checkTransactionDetails({
+        information: [
+          { key: 'Fiscal year', value: testData.fiscalYear.code },
+          { key: 'Amount', value: '$1.00' },
+          { key: 'Source', value: testData.order.poNumber },
+          { key: 'Type', value: 'Encumbrance' },
+          { key: 'From', value: testData.fund.name },
+          { key: 'Awaiting payment', value: '$0.00' },
+          { key: 'Expended', value: '$0.00' },
+          { key: 'Status', value: 'Unreleased' },
+        ],
+      });
+    },
+  );
+});

--- a/cypress/support/fragments/orders/orderLineDetails.js
+++ b/cypress/support/fragments/orders/orderLineDetails.js
@@ -18,6 +18,7 @@ const orderLineDetailsSection = Section({ id: 'order-lines-details' });
 const paneHeaderOrderLinesDetailes = orderLineDetailsSection.find(
   PaneHeader({ id: 'paneHeaderorder-lines-details' }),
 );
+const backToOrderButton = Button({ id: 'clickable-backToPO' });
 const actionsButton = Button('Actions');
 
 const itemDetailsSection = orderLineDetailsSection.find(Section({ id: 'ItemDetails' }));
@@ -28,6 +29,9 @@ const locationDetailsSection = orderLineDetailsSection.find(Section({ id: 'locat
 export default {
   waitLoading() {
     cy.expect(orderLineDetailsSection.exists());
+  },
+  backToOrderDetails() {
+    cy.do(backToOrderButton.click());
   },
   checkOrderLineDetails({ purchaseOrderLineInformation = [] } = {}) {
     purchaseOrderLineInformation.forEach(({ key, value }) => {
@@ -85,6 +89,10 @@ export default {
         );
       }
     });
+
+    if (!records.length) {
+      cy.expect(fundDistributionsSection.has({ text: including('The list contains no items') }));
+    }
   },
   checkLocationsSection({ locations = [] }) {
     locations.forEach((locationInformation, index) => {

--- a/cypress/support/fragments/orders/orderLineEditForm.js
+++ b/cypress/support/fragments/orders/orderLineEditForm.js
@@ -1,4 +1,12 @@
-import { Button, Section, Select, matching } from '../../../../interactors';
+import {
+  Button,
+  Section,
+  Select,
+  Selection,
+  SelectionList,
+  including,
+  matching,
+} from '../../../../interactors';
 import OrderStates from './orderStates';
 import InteractorsTools from '../../utils/interactorsTools';
 
@@ -34,6 +42,22 @@ export default {
     if (orderLine.paymentStatus) {
       cy.do(orderLineFields.paymentStatus.choose(orderLine.paymentStatus));
     }
+  },
+  addFundDistribution() {
+    cy.do(Button('Add fund distribution').click());
+  },
+  selectDropDownValue(label, option) {
+    cy.do([
+      Selection(including(label)).open(),
+      SelectionList().filter(option),
+      SelectionList().select(including(option)),
+    ]);
+  },
+  selectFundDistribution(fund) {
+    this.selectDropDownValue('Fund ID', fund);
+  },
+  selectExpenseClass(expenseClass) {
+    this.selectDropDownValue('Expense class', expenseClass);
   },
   clickCancelButton() {
     cy.do(cancelButtom.click());

--- a/cypress/support/fragments/settings/acquisitionUnits/acquisitionUnits.js
+++ b/cypress/support/fragments/settings/acquisitionUnits/acquisitionUnits.js
@@ -1,3 +1,4 @@
+import uuid from 'uuid';
 import {
   Button,
   TextField,
@@ -25,11 +26,26 @@ const checkboxAll = Checkbox();
 const searchButton = Button('Search');
 const nameTextField = TextField({ name: 'name' });
 
+const getDefaultAcquisitionUnit = ({
+  name,
+  protectRead = false,
+  protectUpdate = true,
+  protectCreate = true,
+  protectDelete = true,
+} = {}) => ({
+  protectRead,
+  protectUpdate,
+  protectCreate,
+  protectDelete,
+  name: name || `autotest_acq_unit_${getRandomPostfix()}`,
+  id: uuid(),
+});
+
 export default {
   defaultAcquisitionUnit: {
     name: `AU_${getRandomPostfix()}`,
   },
-
+  getDefaultAcquisitionUnit,
   waitLoading: () => {
     cy.expect(auListPane.exists());
   },
@@ -138,5 +154,29 @@ export default {
     cy.expect(assignedUsersSection.exists());
     cy.do([Checkbox('Edit').click(), saveAUButton.click()]);
     cy.expect(auPaneDetails.find(assignedUsersSection).exists());
+  },
+  getAcquisitionUnitViaApi(searchParams) {
+    return cy
+      .okapiRequest({
+        path: 'acquisitions-units/units',
+        searchParams,
+        isDefaultSearchParamsRequired: false,
+      })
+      .then(({ body }) => body);
+  },
+  createAcquisitionUnitViaApi(acqUnit) {
+    return cy
+      .okapiRequest({
+        method: 'POST',
+        path: 'acquisitions-units/units',
+        body: acqUnit,
+      })
+      .then(({ body }) => body);
+  },
+  deleteAcquisitionUnitViaApi(acqUnitId) {
+    return cy.okapiRequest({
+      method: 'DELETE',
+      path: `acquisitions-units/units/${acqUnitId}`,
+    });
   },
 };


### PR DESCRIPTION
[C407655](https://foliotest.testrail.io/index.php?/cases/view/407655)
***
[Allure report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/4956/allure)
***

<img width="846" alt="Screenshot 2023-10-19 at 20 33 51" src="https://github.com/folio-org/stripes-testing/assets/16187978/c0c8b08f-a5ea-4049-a91d-c56cd78aa5c5">
