### PR TITLE
C380514: "UTC" is displayed in "Period begin date" and "Period end date" fields when create or view fiscal year (Orchid +) (thunderjet) (TaaS)

### DIFF
--- a/cypress/e2e/finance/fiscalYears/utc-is-displayed-when-create-or-view-fiscal-year.cy.js
+++ b/cypress/e2e/finance/fiscalYears/utc-is-displayed-when-create-or-view-fiscal-year.cy.js
@@ -1,0 +1,39 @@
+import TopMenu from '../../../support/fragments/topMenu';
+import FiscalYears from '../../../support/fragments/finance/fiscalYears/fiscalYears';
+import testType from '../../../support/dictionary/testTypes';
+import devTeams from '../../../support/dictionary/devTeams';
+import permissions from '../../../support/dictionary/permissions';
+import Users from '../../../support/fragments/users/users';
+import NewFiscalYear from '../../../support/fragments/finance/fiscalYears/newFiscalYear';
+
+describe('ui-finance: Fiscal Year', () => {
+  const defaultFiscalYear = { ...NewFiscalYear.defaultFiscalYear };
+  let user;
+  before(() => {
+    cy.getAdminToken();
+    cy.createTempUser([permissions.uiFinanceViewEditCreateFiscalYear.gui]).then(
+      (userProperties) => {
+        user = userProperties;
+        cy.login(userProperties.username, userProperties.password, {
+          path: TopMenu.fiscalYearPath,
+          waiter: FiscalYears.waitLoading,
+        });
+      },
+    );
+  });
+  after(() => {
+    cy.loginAsAdmin({ path: TopMenu.fiscalYearPath, waiter: FiscalYears.waitLoading });
+    FiscalYears.selectFY(defaultFiscalYear.name);
+    FiscalYears.deleteFiscalYearViaActions();
+    Users.deleteViaApi(user.userId);
+  });
+
+  it(
+    'C380514: "UTC" is displayed in "Period begin date" and "Period end date" fields when create or view fiscal year (Orchid +) (thunderjet) (TaaS)',
+    { tags: [testType.criticalPath, devTeams.thunderjet] },
+    () => {
+      FiscalYears.createDefaultFiscalYear(defaultFiscalYear);
+      FiscalYears.checkCreatedFiscalYear(defaultFiscalYear.name);
+    },
+  );
+});

--- a/cypress/support/fragments/finance/fiscalYears/fiscalYears.js
+++ b/cypress/support/fragments/finance/fiscalYears/fiscalYears.js
@@ -67,6 +67,13 @@ export default {
     cy.do(Pane({ id: 'fiscal-year-results-pane' }).find(Link(fiscalYear)).click());
   },
 
+  waitLoading: () => {
+    cy.expect([
+      Pane({ id: 'fiscal-year-filters-pane' }).exists,
+      Pane({ id: 'fiscal-year-results-pane' }).exists,
+    ]);
+  },
+
   waitForFiscalYearDetailsLoading: () => {
     cy.do(Pane({ id: 'pane-fiscal-year-details' }).exists);
   },


### PR DESCRIPTION
***
[C380514](https://foliotest.testrail.io/index.php?/cases/view/380514)
***
![Screenshot_335](https://github.com/folio-org/stripes-testing/assets/132610395/86c7e66a-d18a-4f96-90b6-944da9f34e15)
