### PR TITLE
C380427 A new MARC bib record is opened in QuickMARC UI (spitfire) (TaaS)

### DIFF
--- a/cypress/e2e/marc-authority/create-new-marc-bib-check-pane.cy.js
+++ b/cypress/e2e/marc-authority/create-new-marc-bib-check-pane.cy.js
@@ -1,0 +1,52 @@
+import { DevTeams, Permissions, TestTypes } from '../../support/dictionary';
+import TopMenu from '../../support/fragments/topMenu';
+import Users from '../../support/fragments/users/users';
+import InventoryInstances from '../../support/fragments/inventory/inventoryInstances';
+import InventoryInstance from '../../support/fragments/inventory/inventoryInstance';
+import QuickMarcEditor from '../../support/fragments/quickMarcEditor';
+
+describe('Create new MARC bib', () => {
+  const testData = {};
+
+  before('Create test data', () => {
+    cy.createTempUser([
+      Permissions.inventoryAll.gui,
+      Permissions.uiQuickMarcQuickMarcBibliographicEditorCreate.gui,
+    ]).then((userProperties) => {
+      testData.user = userProperties;
+
+      cy.login(testData.user.username, testData.user.password, {
+        path: TopMenu.inventoryPath,
+        waiter: InventoryInstances.waitContentLoading,
+      });
+    });
+  });
+
+  after('Delete test data', () => {
+    Users.deleteViaApi(testData.user.userId);
+  });
+
+  it(
+    'C380427 A new "MARC bib" record is opened in QuickMARC UI (spitfire) (TaaS)',
+    {
+      tags: [TestTypes.criticalPath, DevTeams.spitfire],
+    },
+    () => {
+      // Open "Inventory" app
+      InventoryInstances.waitContentLoading();
+      // Click on "Actions" button in second pane
+      // Click on "+New MARC Bib Record" option in expanded "Actions" menu
+      InventoryInstance.newMarcBibRecord();
+      // Verify certain fields pre-populated with default values
+      QuickMarcEditor.checkDefaultContent();
+      // Close the pane with title "Create a new MARC bib record" by clicking on "x" icon in the upper left corner.
+      QuickMarcEditor.closeUsingCrossButton();
+      InventoryInstances.waitContentLoading();
+      // Repeat steps 2-3.
+      InventoryInstance.newMarcBibRecord();
+      // Click on the "Cancel" button.
+      QuickMarcEditor.closeWithoutSaving();
+      InventoryInstances.waitContentLoading();
+    },
+  );
+});

--- a/cypress/support/fragments/quickMarcEditor.js
+++ b/cypress/support/fragments/quickMarcEditor.js
@@ -261,6 +261,7 @@ defaultFieldValues.getSourceContent = (contentInQuickMarcEditor) => contentInQui
 const requiredRowsTags = ['LDR', '001', '005', '008', '999'];
 const readOnlyAuthorityTags = ['LDR', '001', '005', '999'];
 const readOnlyHoldingsTags = ['001', '004', '005', '999'];
+const expectedFields = ['LDR', '001', '008', '005', '245', '999'];
 
 const getRowInteractorByRowNumber = (specialRowNumber) => QuickMarcEditor().find(QuickMarcEditorRow({ index: specialRowNumber }));
 const getRowInteractorByTagName = (tagName) => QuickMarcEditor().find(QuickMarcEditorRow({ tagValue: tagName }));
@@ -1530,5 +1531,15 @@ export default {
 
   clickUnlinkButton: () => {
     cy.do(buttonLink.click());
+  },
+
+  checkDefaultContent() {
+    this.checkContent('00000n\\\\\\a2200000uu\\4500', 0);
+    this.checkFieldsExist(expectedFields);
+    this.checkEmptyContent('001');
+    this.checkEmptyContent('005');
+    this.checkEmptyContent('999');
+    this.checkEmptyContent('008');
+    this.verifyTagField(4, '245', '\\', '\\', '$a ', '');
   },
 };

--- a/cypress/support/fragments/quickMarcEditor.js
+++ b/cypress/support/fragments/quickMarcEditor.js
@@ -1541,5 +1541,6 @@ export default {
     this.checkEmptyContent('999');
     this.checkEmptyContent('008');
     this.verifyTagField(4, '245', '\\', '\\', '$a ', '');
+    this.checkInitialContent(4);
   },
 };


### PR DESCRIPTION
[testRail](https://foliotest.testrail.io/index.php?/cases/view/380427)
[AllureReport](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/5079/allure)
![image](https://github.com/folio-org/stripes-testing/assets/147595219/dc8434fa-247f-40b2-a8fe-331a32aa71f2)
