### PR TITLE
[354281] “Electronic” format fields cleared when changing order format (thunderjet) (TaaS)

### DIFF
--- a/cypress/e2e/orders/electronic-format-fields-cleared-when-change-format-to-physical.cy.js
+++ b/cypress/e2e/orders/electronic-format-fields-cleared-when-change-format-to-physical.cy.js
@@ -1,0 +1,174 @@
+import { DevTeams, TestTypes, Permissions } from '../../support/dictionary';
+import { Locations, ServicePoints } from '../../support/fragments/settings/tenant';
+import { NewOrder, BasicOrderLine, Orders } from '../../support/fragments/orders';
+import InventoryHoldings from '../../support/fragments/inventory/holdings/inventoryHoldings';
+import Organizations from '../../support/fragments/organizations/organizations';
+import NewOrganization from '../../support/fragments/organizations/newOrganization';
+import TopMenu from '../../support/fragments/topMenu';
+import Users from '../../support/fragments/users/users';
+import { ORDER_STATUSES } from '../../support/constants';
+
+describe('Orders', () => {
+  const organization = NewOrganization.getDefaultOrganization();
+  const testData = {
+    organization,
+    servicePoint: ServicePoints.getDefaultServicePoint(),
+    order: {},
+    user: {},
+  };
+
+  before('Create test data', () => {
+    cy.getAdminToken().then(() => {
+      Organizations.createOrganizationViaApi(testData.organization);
+
+      ServicePoints.createViaApi(testData.servicePoint)
+        .then(() => {
+          testData.location = Locations.getDefaultLocation({
+            servicePointId: testData.servicePoint.id,
+          }).location;
+
+          Locations.createViaApi(testData.location);
+        })
+        .then(() => {
+          cy.getMaterialTypes({ limit: 1 }).then(({ id: materialTypeId }) => {
+            testData.order = NewOrder.getDefaultOrder({ vendorId: testData.organization.id });
+            testData.orderLine = {
+              ...BasicOrderLine.getDefaultOrderLine(),
+              cost: {
+                currency: 'USD',
+                discountType: 'percentage',
+                quantityPhysical: 1,
+                quantityElectronic: 1,
+                listUnitPriceElectronic: 10,
+                listUnitPrice: 10,
+              },
+              orderFormat: 'P/E Mix',
+              eresource: {
+                createInventory: 'Instance, Holding',
+                accessProvider: testData.organization.id,
+              },
+              physical: {
+                createInventory: 'Instance, Holding, Item',
+                materialType: materialTypeId,
+              },
+              locations: [
+                {
+                  locationId: testData.location.id,
+                  quantityPhysical: 1,
+                  quantityElectronic: 1,
+                },
+              ],
+            };
+
+            Orders.createOrderWithOrderLineViaApi(testData.order, testData.orderLine).then(
+              (order) => {
+                testData.order = order;
+              },
+            );
+          });
+        });
+    });
+
+    cy.createTempUser([Permissions.uiOrdersEdit.gui, Permissions.uiOrdersView.gui]).then(
+      (userProperties) => {
+        testData.user = userProperties;
+
+        cy.login(testData.user.username, testData.user.password, {
+          path: TopMenu.ordersPath,
+          waiter: Orders.waitLoading,
+        });
+      },
+    );
+  });
+
+  after('Delete test data', () => {
+    Organizations.deleteOrganizationViaApi(testData.organization.id);
+    Orders.deleteOrderViaApi(testData.order.id);
+    InventoryHoldings.deleteHoldingRecordByLocationIdViaApi(testData.location.id);
+    Locations.deleteViaApi(testData.location);
+    ServicePoints.deleteViaApi(testData.servicePoint.id);
+    Users.deleteViaApi(testData.user.userId);
+  });
+
+  it(
+    'C354281 “Electronic” format specific fields are cleared when changing order format from "P/E Mix" to "Physical Resource" (thunderjet) (TaaS)',
+    { tags: [TestTypes.extendedPath, DevTeams.thunderjet] },
+    () => {
+      // Click on the Order record from preconditions
+      const OrderDetails = Orders.selectOrderByPONumber(testData.order.poNumber);
+      OrderDetails.checkOrderStatus(ORDER_STATUSES.PENDING);
+
+      // Click on the PO line record in "PO lines" accordion
+      const OrderLineDetails = OrderDetails.openPolDetails(testData.orderLine.titleOrPackage);
+      OrderLineDetails.checkOrderLineDetails({
+        purchaseOrderLineInformation: [{ key: 'Order format', value: 'P/E Mix' }],
+      });
+
+      // Click "Actions" button, Select "Edit" option
+      const OrderLineEditForm = OrderLineDetails.openOrderLineEditForm();
+
+      // Choose "Physical resource" from "Order format" dropdown, Click "Save & close" button
+      OrderLineEditForm.fillOrderLineFields({
+        poLineDetails: { orderFormat: 'Physical resource' },
+        costDetails: {
+          physicalUnitPrice: '10',
+          quantityPhysical: '1',
+        },
+      });
+      OrderLineEditForm.clickSaveButton({ orderLineUpdated: false });
+      OrderLineEditForm.checkValidatorError({
+        locationDetails: {
+          label: 'Quantity electronic',
+          error:
+            'Locations electronic quantity should be empty or match with PO line electronic quantity',
+        },
+      });
+
+      // Delete prefilled value from "Quantity electronic" field in "Location" accordion and click "Save & close" button
+      OrderLineEditForm.fillOrderLineFields({
+        locationDetails: [{ quantityElectronic: '0' }],
+      });
+      OrderLineEditForm.clickSaveButton();
+      OrderLineDetails.checkOrderLineDetails({
+        purchaseOrderLineInformation: [{ key: 'Order format', value: 'Physical Resource' }],
+      });
+
+      // #7 Click "Back to PO" arrow on the top of "PO Line details" pane
+      // "Purchase order" pane is displayed
+      OrderLineDetails.backToOrderDetails();
+
+      // Click "Actions" button, Select "Open" option, Slick "Submit" button
+      OrderDetails.openOrder({ orderNumber: testData.order.poNumber });
+      OrderDetails.checkOrderStatus(ORDER_STATUSES.OPEN);
+
+      // Click on the PO line record in "PO lines" accordion
+      OrderDetails.openPolDetails(testData.orderLine.titleOrPackage);
+      OrderLineDetails.checkOrderLineDetails({
+        purchaseOrderLineInformation: [{ key: 'Order format', value: 'Physical Resource' }],
+      });
+
+      // Click "Actions" button, Select "Edit" option
+      OrderLineDetails.openOrderLineEditForm();
+
+      // Add receiving note in "Item details" accordion and click "Save & close" button
+      OrderLineEditForm.fillOrderLineFields({
+        itemDetails: { receivingNote: 'some note' },
+      });
+      OrderLineEditForm.clickSaveButton();
+      OrderLineDetails.checkOrderLineDetails({
+        purchaseOrderLineInformation: [{ key: 'Order format', value: 'Physical Resource' }],
+        costDetails: [
+          { key: 'Quantity physical', value: '1' },
+          { key: 'Quantity electronic', value: '-' },
+        ],
+        locationDetails: [
+          [
+            { key: 'Holding', value: testData.location.name },
+            { key: 'Quantity physical', value: 1 },
+            { key: 'Quantity electronic', value: 1 },
+          ],
+        ],
+      });
+    },
+  );
+});

--- a/cypress/support/fragments/orders/orderLineDetails.js
+++ b/cypress/support/fragments/orders/orderLineDetails.js
@@ -25,6 +25,7 @@ const actionsButton = Button('Actions');
 const itemDetailsSection = orderLineDetailsSection.find(Section({ id: 'ItemDetails' }));
 const purchaseOrderLineSection = orderLineDetailsSection.find(Section({ id: 'poLine' }));
 const fundDistributionsSection = orderLineDetailsSection.find(Section({ id: 'FundDistribution' }));
+const costDetailsSection = orderLineDetailsSection.find(Section({ id: 'CostDetails' }));
 const locationDetailsSection = orderLineDetailsSection.find(Section({ id: 'location' }));
 const exportDetailsSection = orderLineDetailsSection.find(Section({ id: 'exportDetails' }));
 
@@ -35,10 +36,18 @@ export default {
   backToOrderDetails() {
     cy.do(backToOrderButton.click());
   },
-  checkOrderLineDetails({ purchaseOrderLineInformation = [] } = {}) {
+  checkOrderLineDetails({ purchaseOrderLineInformation = [], costDetails, locationDetails } = {}) {
     purchaseOrderLineInformation.forEach(({ key, value }) => {
       cy.expect(purchaseOrderLineSection.find(KeyValue(key)).has({ value: including(value) }));
     });
+
+    if (costDetails) {
+      this.checkCostDetailsSection(costDetails);
+    }
+
+    if (locationDetails) {
+      this.checkLocationsSection(locationDetails);
+    }
   },
   openInventoryItem() {
     cy.do(itemDetailsSection.find(KeyValue('Title')).find(Link()).click());
@@ -146,7 +155,12 @@ export default {
       }
     });
   },
-  checkLocationsSection({ locations = [] }) {
+  checkCostDetailsSection({ costDetails = [] } = {}) {
+    costDetails.forEach(({ key, value }) => {
+      cy.expect(costDetailsSection.find(KeyValue(key)).has({ value: including(value) }));
+    });
+  },
+  checkLocationsSection({ locations = [] } = {}) {
     locations.forEach((locationInformation, index) => {
       locationInformation.forEach(({ key, value }) => {
         cy.expect(

--- a/cypress/support/fragments/orders/orderLineEditForm.js
+++ b/cypress/support/fragments/orders/orderLineEditForm.js
@@ -4,6 +4,8 @@ import {
   Select,
   Selection,
   SelectionList,
+  TextArea,
+  TextField,
   including,
   matching,
 } from '../../../../interactors';
@@ -11,14 +13,27 @@ import OrderStates from './orderStates';
 import InteractorsTools from '../../utils/interactorsTools';
 
 const orderLineEditFormRoot = Section({ id: 'pane-poLineForm' });
+const itemDetailsSection = orderLineEditFormRoot.find(Section({ id: 'itemDetails' }));
 const orderLineDetailsSection = orderLineEditFormRoot.find(Section({ id: 'lineDetails' }));
+const costDetailsSection = orderLineEditFormRoot.find(Section({ id: 'costDetails' }));
+const locationSection = orderLineEditFormRoot.find(Section({ id: 'location' }));
 
 const cancelButtom = Button('Cancel');
 const saveButtom = Button('Save & close');
 
+const itemDetailsFields = {
+  receivingNote: itemDetailsSection.find(TextArea({ name: 'details.receivingNote' })),
+};
+
 const orderLineFields = {
+  orderFormat: orderLineDetailsSection.find(Select({ name: 'orderFormat' })),
   receiptStatus: orderLineDetailsSection.find(Select({ name: 'receiptStatus' })),
   paymentStatus: orderLineDetailsSection.find(Select({ name: 'paymentStatus' })),
+};
+
+const costDetailsFields = {
+  physicalUnitPrice: costDetailsSection.find(TextField({ name: 'cost.listUnitPrice' })),
+  quantityPhysical: costDetailsSection.find(TextField({ name: 'cost.quantityPhysical' })),
 };
 
 const buttons = {
@@ -36,12 +51,48 @@ export default {
     });
   },
   fillOrderLineFields(orderLine) {
+    if (orderLine.itemDetails) {
+      this.fillItemDetails(orderLine.itemDetails);
+    }
+    if (orderLine.poLineDetails) {
+      this.fillPoLineDetails(orderLine.poLineDetails);
+    }
+    if (orderLine.costDetails) {
+      this.fillCostDetails(orderLine.costDetails);
+    }
+    if (orderLine.locationDetails) {
+      this.fillLocationDetails(orderLine.locationDetails);
+    }
     if (orderLine.receiptStatus) {
       cy.do(orderLineFields.receiptStatus.choose(orderLine.receiptStatus));
     }
     if (orderLine.paymentStatus) {
       cy.do(orderLineFields.paymentStatus.choose(orderLine.paymentStatus));
     }
+  },
+  fillItemDetails(itemDetails) {
+    Object.entries(itemDetails).forEach(([key, value]) => {
+      cy.do(itemDetailsFields[key].fillIn(value));
+    });
+  },
+  fillPoLineDetails(poLineDetails) {
+    if (poLineDetails.orderFormat) {
+      cy.do(orderLineFields.orderFormat.choose(poLineDetails.orderFormat));
+    }
+  },
+  fillCostDetails(costDetails) {
+    Object.entries(costDetails).forEach(([key, value]) => {
+      cy.do(costDetailsFields[key].fillIn(value));
+    });
+  },
+  fillLocationDetails(locationDetails) {
+    locationDetails.forEach((location, index) => {
+      Object.entries(location).forEach(([key, value]) => {
+        cy.do(
+          locationSection.find(TextField({ name: `locations[${index}].${key}` })).fillIn(value),
+        );
+      });
+    });
   },
   addFundDistribution() {
     cy.do(Button('Add fund distribution').click());
@@ -58,6 +109,15 @@ export default {
   },
   selectExpenseClass(expenseClass) {
     this.selectDropDownValue('Expense class', expenseClass);
+  },
+  checkValidatorError({ locationDetails } = {}) {
+    if (locationDetails) {
+      cy.expect(
+        locationSection
+          .find(TextField({ label: including(locationDetails.label) }))
+          .has({ error: locationDetails.error }),
+      );
+    }
   },
   clickCancelButton() {
     cy.do(cancelButtom.click());


### PR DESCRIPTION
[C354281](https://foliotest.testrail.io/index.php?/cases/view/354281)
***
[Allure report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/5188/allure)
***

<img width="846" alt="Screenshot 2023-10-31 at 10 05 34" src="https://github.com/folio-org/stripes-testing/assets/16187978/6cea1c39-9bd7-4ed8-bed5-128e759c9a77">
