### PR TITLE
C399095 Verify that "Browse call numbers" result list correctly displays preceding results before the one being searched (all "Items" in different "Instances") (Spitfire)

### DIFF
--- a/cypress/e2e/inventory/call-number/browse-call-numbers-result-list-displays-preceding-result.cy.js
+++ b/cypress/e2e/inventory/call-number/browse-call-numbers-result-list-displays-preceding-result.cy.js
@@ -1,0 +1,112 @@
+import { DevTeams, TestTypes, Permissions } from '../../../support/dictionary';
+import { Locations, ServicePoints } from '../../../support/fragments/settings/tenant';
+import TopMenu from '../../../support/fragments/topMenu';
+import InventoryInstances from '../../../support/fragments/inventory/inventoryInstances';
+import InventorySearchAndFilter from '../../../support/fragments/inventory/inventorySearchAndFilter';
+import Users from '../../../support/fragments/users/users';
+import { ITEM_STATUS_NAMES } from '../../../support/constants';
+import { getTestEntityValue, randomFourDigitNumber } from '../../../support/utils/stringTools';
+import Location from '../../../support/fragments/settings/tenant/locations/newLocation';
+import BrowseCallNumber from '../../../support/fragments/inventory/search/browseCallNumber';
+
+describe('inventory', () => {
+  describe('Call Number Browse', () => {
+    let callNumberIncrement = 30;
+    let barcodeId = 111;
+    const numberOfInventory = 25;
+    const callNumbers = [];
+    const barcodes = [];
+    [...Array(numberOfInventory)].forEach(() => barcodes.push(`399095${++barcodeId}`));
+    [...Array(numberOfInventory)].forEach(() => callNumbers.push(`E 3184 S75 12${++callNumberIncrement}`));
+    const testData = {
+      userServicePoint: ServicePoints.getDefaultServicePointWithPickUpLocation(),
+    };
+
+    before('Create test data', () => {
+      cy.getAdminToken().then(() => {
+        ServicePoints.createViaApi(testData.userServicePoint);
+        testData.defaultLocation = Location.getDefaultLocation(testData.userServicePoint.id);
+        Location.createViaApi(testData.defaultLocation);
+        cy.getInstanceTypes({ limit: 1 }).then((instanceTypes) => {
+          testData.instanceTypeId = instanceTypes[0].id;
+        });
+        cy.getHoldingTypes({ limit: 1 }).then((holdingTypes) => {
+          testData.holdingTypeId = holdingTypes[0].id;
+        });
+        cy.createLoanType({
+          name: getTestEntityValue('type'),
+        }).then((loanType) => {
+          testData.loanTypeId = loanType.id;
+        });
+        cy.getMaterialTypes({ limit: 1 })
+          .then((materialTypes) => {
+            testData.materialTypeId = materialTypes.id;
+            testData.materialType = materialTypes.name;
+          })
+          .then(() => {
+            barcodes.forEach((barcode, i) => {
+              InventoryInstances.createFolioInstanceViaApi({
+                instance: {
+                  instanceTypeId: testData.instanceTypeId,
+                  title: `instance_${randomFourDigitNumber()}`,
+                },
+                holdings: [
+                  {
+                    holdingsTypeId: testData.holdingTypeId,
+                    permanentLocationId: testData.defaultLocation.id,
+                    callNumber: callNumbers[i],
+                  },
+                ],
+                items: [
+                  {
+                    barcode: barcodes[i],
+                    status: { name: ITEM_STATUS_NAMES.AVAILABLE },
+                    permanentLoanType: { id: testData.loanTypeId },
+                    materialType: { id: testData.materialTypeId },
+                  },
+                ],
+              });
+            });
+          });
+      });
+      cy.createTempUser([Permissions.inventoryAll.gui]).then((userProperties) => {
+        testData.user = userProperties;
+
+        cy.login(testData.user.username, testData.user.password, {
+          path: TopMenu.inventoryPath,
+          waiter: InventoryInstances.waitContentLoading,
+        });
+      });
+    });
+
+    after('Delete test data', () => {
+      cy.getAdminToken();
+      barcodes.forEach((barcode) => {
+        InventoryInstances.deleteInstanceAndHoldingRecordAndAllItemsViaApi(barcode);
+      });
+      ServicePoints.deleteViaApi(testData.userServicePoint.id);
+      Locations.deleteViaApi(testData.defaultLocation);
+      Users.deleteViaApi(testData.user.userId);
+      cy.deleteLoanType(testData.loanTypeId);
+    });
+
+    it(
+      'C399095 Verify that "Browse call numbers" result list correctly displays preceding results before the one being searched (all "Items" in different "Instances") (spitfire) (TaaS)',
+      { tags: [TestTypes.criticalPath, DevTeams.spitfire] },
+      () => {
+        // Fill in the input field at "Search & filter" pane with the "Call number" value which is alphabetically the first one out of all 25 (see Preconditions)
+        // (For example, "E 3184 S75 1231")
+        InventorySearchAndFilter.selectBrowseCallNumbers();
+        InventorySearchAndFilter.browseSearch(callNumbers[0]);
+        BrowseCallNumber.valueInResultTableIsHighlighted(callNumbers[0]);
+        BrowseCallNumber.resultRowsIsInRequiredOder(callNumbers);
+
+        // Fill in the input field at "Search & filter" pane with the "Call number" value which is alphabetically not the first one out of all 25 (see Preconditions)
+        // (For example, "E 3184 S75 1238")
+        InventorySearchAndFilter.browseSearch(callNumbers[7]);
+        BrowseCallNumber.valueInResultTableIsHighlighted(callNumbers[7]);
+        BrowseCallNumber.resultRowsIsInRequiredOder(callNumbers.slice(8));
+      },
+    );
+  });
+});

--- a/cypress/support/fragments/inventory/search/browseCallNumber.js
+++ b/cypress/support/fragments/inventory/search/browseCallNumber.js
@@ -1,6 +1,8 @@
 import {
   Button,
   including,
+  MultiColumnList,
+  MultiColumnListRow,
   MultiColumnListCell,
   MultiColumnListHeader,
   Section,
@@ -8,6 +10,7 @@ import {
 
 const browseButton = Button({ id: 'mode-navigation-browse' });
 const instanceDetailsPane = Section({ id: 'pane-instancedetails' });
+const resultList = MultiColumnList({ id: 'browse-results-list-callNumbers' });
 
 export default {
   clickOnResult(searchQuery) {
@@ -88,6 +91,14 @@ export default {
         const rowNumber = +element.parentElement.getAttribute('data-row-inner');
         cy.expect(MultiColumnListCell(numberOfTitles, { row: rowNumber }).exists());
       }),
+    );
+  },
+
+  checkValueInRowAndColumnName(indexRow, columnName, value) {
+    cy.expect(
+      resultList
+        .find(MultiColumnListCell({ row: indexRow, column: columnName }))
+        .has({ content: value }),
     );
   },
 };


### PR DESCRIPTION
https://foliotest.testrail.io/index.php?/cases/view/399095
https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/5405/allure/
![image](https://github.com/folio-org/stripes-testing/assets/50654975/9edfe244-3c1a-4abb-804f-e65e436eb6d9)
