### PR TITLE
C360537 Verify that the "Confirm changes" button is disabled until all fields are filled in Email update (firebird) (TaaS)

### DIFF
--- a/cypress/e2e/bulk-edit/in-app/bulk-edit-in-app-email-fields.cy.js
+++ b/cypress/e2e/bulk-edit/in-app/bulk-edit-in-app-email-fields.cy.js
@@ -1,19 +1,56 @@
-import devTeams from '../../../support/dictionary/devTeams';
+import TopMenu from '../../../support/fragments/topMenu';
 import testTypes from '../../../support/dictionary/testTypes';
+import permissions from '../../../support/dictionary/permissions';
+import BulkEditSearchPane from '../../../support/fragments/bulk-edit/bulk-edit-search-pane';
+import FileManager from '../../../support/utils/fileManager';
+import getRandomPostfix from '../../../support/utils/stringTools';
+import devTeams from '../../../support/dictionary/devTeams';
+import BulkEditActions from '../../../support/fragments/bulk-edit/bulk-edit-actions';
+import Users from '../../../support/fragments/users/users';
+
+let user;
+const userUUIDsFileName = `userUUIDs_${getRandomPostfix()}.csv`;
 
 describe('bulk-edit', () => {
   describe('in-app approach', () => {
     before('create test data', () => {
+      cy.createTempUser([permissions.bulkEditUpdateRecords.gui, permissions.uiUserEdit.gui], 'staff').then(
+        (userProperties) => {
+          user = userProperties;
+          cy.login(user.username, user.password, {
+            path: TopMenu.bulkEditPath,
+            waiter: BulkEditSearchPane.waitLoading,
+          });
+          FileManager.createFile(`cypress/fixtures/${userUUIDsFileName}`, user.userId);
+        },
+      );
     });
 
     after('delete test data', () => {
+      cy.getAdminToken();
+      FileManager.deleteFile(`cypress/fixtures/${userUUIDsFileName}`);
+      Users.deleteViaApi(user.userId);
     });
 
     it(
       'C360537 Verify that the "Confirm changes" button is disabled until all fields are filled in Email update (firebird) (TaaS)',
       { tags: [testTypes.extendedPath, devTeams.firebird] },
       () => {
+        BulkEditSearchPane.verifyDragNDropUsersUUIDsArea();
+        BulkEditSearchPane.uploadFile(userUUIDsFileName);
+        BulkEditSearchPane.waitFileUploading();
 
+        BulkEditActions.openActions();
+        BulkEditSearchPane.changeShowColumnCheckboxIfNotYet('Email');
+        BulkEditActions.openInAppStartBulkEditFrom();
+        const oldEmailDomain = 'folio.org';
+        const newEmailDomain = 'google.com';
+        BulkEditActions.replaceEmail(oldEmailDomain, newEmailDomain);
+        BulkEditActions.addNewBulkEditFilterString();
+        BulkEditActions.fillPatronGroup('faculty (Faculty Member)', 1);
+        BulkEditActions.confirmChanges();
+        BulkEditActions.commitChanges();
+        BulkEditSearchPane.verifyChangedResults(`test@${newEmailDomain}`);
       }
     );
   });

--- a/cypress/e2e/bulk-edit/in-app/bulk-edit-in-app-email-fields.cy.js
+++ b/cypress/e2e/bulk-edit/in-app/bulk-edit-in-app-email-fields.cy.js
@@ -1,0 +1,20 @@
+import devTeams from '../../../support/dictionary/devTeams';
+import testTypes from '../../../support/dictionary/testTypes';
+
+describe('bulk-edit', () => {
+  describe('in-app approach', () => {
+    before('create test data', () => {
+    });
+
+    after('delete test data', () => {
+    });
+
+    it(
+      'C360537 Verify that the "Confirm changes" button is disabled until all fields are filled in Email update (firebird) (TaaS)',
+      { tags: [testTypes.extendedPath, devTeams.firebird] },
+      () => {
+
+      }
+    );
+  });
+});

--- a/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
+++ b/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
@@ -190,7 +190,9 @@ export default {
     cy.do(
       RepeatableFieldItem({ index: rowIndex }).find(bulkPageSelections.valueType).choose('Email'),
     );
+    BulkEditSearchPane.isConfirmButtonDisabled(true);
     getEmailField().first().type(oldEmailDomain);
+    BulkEditSearchPane.isConfirmButtonDisabled(true);
     getEmailField().eq(2).type(newEmailDomain);
   },
 


### PR DESCRIPTION
https://foliotest.testrail.io/index.php?/cases/view/360537
![image](https://github.com/folio-org/stripes-testing/assets/147148372/8953cb5f-6e4c-43cf-aeb9-499da0818355)
