### PR TITLE
C375111: Encumbered amount is not changed after deleting received piece when related paid invoice exists (thunderjet) (TaaS)

### DIFF
--- a/cypress/e2e/orders/encumbered-amount-is-not-changed-after-deleting-received-piece-with-paid-invoice.cy.js
+++ b/cypress/e2e/orders/encumbered-amount-is-not-changed-after-deleting-received-piece-with-paid-invoice.cy.js
@@ -107,6 +107,7 @@ describe('Orders', () => {
       // Need to wait, while data will be loaded
       cy.wait(4000);
       Invoices.approveInvoice();
+      Invoices.payInvoice();
     });
     cy.createTempUser([
       permissions.uiInventoryViewInstances.gui,
@@ -128,7 +129,7 @@ describe('Orders', () => {
   });
 
   it(
-    'C375110: Encumbered amount is not changed after deleting received piece when related approved invoice exists (thunderjet) (TaaS)',
+    'C375111: Encumbered amount is not changed after deleting received piece when related paid invoice exists (thunderjet) (TaaS)',
     { tags: ['extended', 'thunderjet'] },
     () => {
       Orders.searchByParameter('PO number', orderNumber);


### PR DESCRIPTION
[C375111](https://foliotest.testrail.io/index.php?/cases/view/375111)
***
[Allure report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/5719/allure)
***
![Screenshot_393](https://github.com/folio-org/stripes-testing/assets/132610395/bda5fdd4-a22a-4feb-8124-a00f7dc7bc8a)

