### PR TITLE
[353968] User can edit 'Renewal note' field on POL (thunderjet) (TaaS)

### DIFF
--- a/cypress/e2e/orders/edit-pol-renewal-note.cy.js
+++ b/cypress/e2e/orders/edit-pol-renewal-note.cy.js
@@ -1,0 +1,77 @@
+import { Permissions } from '../../support/dictionary';
+import { NewOrder, Orders, BasicOrderLine } from '../../support/fragments/orders';
+import { NewOrganization, Organizations } from '../../support/fragments/organizations';
+import TopMenu from '../../support/fragments/topMenu';
+import Users from '../../support/fragments/users/users';
+import getRandomPostfix from '../../support/utils/stringTools';
+
+describe('Orders', () => {
+  const testData = {
+    renewalNote: `autotest_renewal_note_${getRandomPostfix()}`,
+    organization: NewOrganization.getDefaultOrganization(),
+    order: {},
+    user: {},
+  };
+
+  before('Create test data', () => {
+    cy.getAdminToken().then(() => {
+      Organizations.createOrganizationViaApi(testData.organization).then(() => {
+        testData.order = NewOrder.getDefaultOngoingOrder({ vendorId: testData.organization.id });
+        testData.orderLine = BasicOrderLine.getDefaultOrderLine();
+
+        Orders.createOrderWithOrderLineViaApi(testData.order, testData.orderLine).then((order) => {
+          testData.order = order;
+
+          Orders.updateOrderViaApi({ ...testData.order, workflowStatus: 'Open' });
+        });
+      });
+    });
+
+    cy.createTempUser([Permissions.uiOrdersEdit.gui, Permissions.uiOrdersView.gui]).then(
+      (userProperties) => {
+        testData.user = userProperties;
+
+        cy.login(testData.user.username, testData.user.password, {
+          path: TopMenu.ordersPath,
+          waiter: Orders.waitLoading,
+        });
+      },
+    );
+  });
+
+  after('Delete test data', () => {
+    cy.getAdminToken().then(() => {
+      Organizations.deleteOrganizationViaApi(testData.organization.id);
+      Orders.deleteOrderViaApi(testData.order.id);
+      Users.deleteViaApi(testData.user.userId);
+    });
+  });
+
+  it(
+    'C353968 A user can edit "Renewal note" field on POL (thunderjet) (TaaS)',
+    { tags: ['extendedPath', 'thunderjet'] },
+    () => {
+      // Click on the record with Order name from precondition
+      const OrderDetails = Orders.selectOrderByPONumber(testData.order.poNumber);
+
+      // Click on the PO line record in "PO line" accordion
+      const OrderLineDetails = OrderDetails.openPolDetails(testData.orderLine.titleOrPackage);
+      OrderLineDetails.checkOngoingOrderInformationSection([{ key: 'Renewal note', value: '' }]);
+
+      // Click "Actions" button, Select "Edit" option
+      const OrderLineEditForm = OrderLineDetails.openOrderLineEditForm();
+      OrderLineEditForm.checkOngoingOrderInformationSection([
+        { label: 'Renewal note', conditions: { value: '' } },
+      ]);
+
+      // Edit "Renewal note" field and click "Save & close" button
+      OrderLineEditForm.fillOrderLineFields({
+        ongoingOrder: { renewalNote: testData.renewalNote },
+      });
+      OrderLineEditForm.clickSaveButton();
+      OrderLineDetails.checkOngoingOrderInformationSection([
+        { key: 'Renewal note', value: testData.renewalNote },
+      ]);
+    },
+  );
+});

--- a/cypress/support/fragments/orders/orderLineEditForm.js
+++ b/cypress/support/fragments/orders/orderLineEditForm.js
@@ -79,6 +79,9 @@ export default {
     if (orderLine.poLineDetails) {
       this.fillPoLineDetails(orderLine.poLineDetails);
     }
+    if (orderLine.ongoingOrder) {
+      this.fillOngoingOrderInformation(orderLine.ongoingOrder);
+    }
     if (orderLine.vendorDetails) {
       this.fillVendorDetails(orderLine.vendorDetails);
     }
@@ -107,6 +110,11 @@ export default {
     }
     if (poLineDetails.orderFormat) {
       cy.do(orderLineFields.orderFormat.choose(poLineDetails.orderFormat));
+    }
+  },
+  fillOngoingOrderInformation({ renewalNote }) {
+    if (renewalNote) {
+      cy.do(ongoingInformationFields['Renewal note'].fillIn(renewalNote));
     }
   },
   fillVendorDetails(vendorDetails) {


### PR DESCRIPTION
[C353968](https://foliotest.testrail.io/index.php?/cases/view/353968)
***
[Allure report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/5754/allure)
***

<img width="849" alt="Screenshot 2023-11-30 at 12 35 22" src="https://github.com/folio-org/stripes-testing/assets/16187978/f046772b-2662-4d02-b64d-e9d5660b5f8e">
