### PR TITLE
C356793 Verify that library staff can cancel a fee/fine as an error for a patron if fee/fine has been fully paid and then fully refunded (vega) (TaaS)

### DIFF
--- a/cypress/e2e/fee-fine/cancel-fee-fine.cy.js
+++ b/cypress/e2e/fee-fine/cancel-fee-fine.cy.js
@@ -1,0 +1,157 @@
+import uuid from 'uuid';
+
+import getRandomPostfix, { getTestEntityValue } from '../../support/utils/stringTools';
+import UserAllFeesFines from '../../support/fragments/users/userAllFeesFines';
+import UsersSearchPane from '../../support/fragments/users/usersSearchPane';
+import PaymentMethods from '../../support/fragments/settings/users/paymentMethods';
+import CancelFeeFine from '../../support/fragments/users/cancelFeeFaine';
+import ManualCharges from '../../support/fragments/settings/users/manualCharges';
+import ServicePoints from '../../support/fragments/settings/tenant/servicePoints/servicePoints';
+import RefundReasons from '../../support/fragments/settings/users/refundReasons';
+import RefundFeeFine from '../../support/fragments/users/refundFeeFine';
+import UsersOwners from '../../support/fragments/settings/users/usersOwners';
+import Permissions from '../../support/dictionary/permissions';
+import PayFeeFine from '../../support/fragments/users/payFeeFaine';
+import NewFeeFine from '../../support/fragments/users/newFeeFine';
+import UsersCard from '../../support/fragments/users/usersCard';
+import UserEdit from '../../support/fragments/users/userEdit';
+import AppPaths from '../../support/fragments/app-paths';
+import TopMenu from '../../support/fragments/topMenu';
+import Users from '../../support/fragments/users/users';
+
+describe('Fees&Fines', () => {
+  describe('Cancel Fees/Fines', () => {
+    const testData = {
+      servicePoint: ServicePoints.getDefaultServicePointWithPickUpLocation(),
+      refundReasonId: uuid(),
+    };
+    const feeFineType = {};
+    const ownerBody = {
+      owner: 'AutotestOwner' + getRandomPostfix(),
+      servicePointOwner: [
+        {
+          value: testData.servicePoint.id,
+          label: testData.servicePoint.name,
+        },
+      ],
+    };
+
+    before('Create test data', () => {
+      cy.getAdminToken();
+      ServicePoints.createViaApi(testData.servicePoint);
+      UsersOwners.createViaApi(ownerBody).then((ownerResponse) => {
+        testData.ownerId = ownerResponse.id;
+        testData.owner = ownerResponse.owner;
+
+        ManualCharges.createViaApi({
+          ...ManualCharges.defaultFeeFineType,
+          ownerId: testData.ownerId,
+        }).then((manualCharge) => {
+          feeFineType.id = manualCharge.id;
+          feeFineType.amount = manualCharge.amount;
+
+          PaymentMethods.createViaApi(testData.ownerId).then((method) => {
+            testData.paymentMethod = method;
+
+            RefundReasons.createViaApi(
+              RefundReasons.getDefaultNewRefundReason(testData.refundReasonId),
+            ).then((reason) => {
+              testData.refundReason = reason.body;
+            });
+
+            cy.createTempUser([
+              Permissions.loansAll.gui,
+              Permissions.loansView.gui,
+              Permissions.loansRenewOverride.gui,
+              Permissions.loansRenew.gui,
+              Permissions.uiFeeFines.gui,
+              Permissions.uiUsersfeefinesView.gui,
+              Permissions.uiUsersView.gui,
+            ])
+              .then((userProperties) => {
+                testData.user = userProperties;
+              })
+              .then(() => {
+                UserEdit.addServicePointViaApi(
+                  testData.servicePoint.id,
+                  testData.user.userId,
+                  testData.servicePoint.id,
+                );
+
+                cy.login(testData.user.username, testData.user.password, {
+                  path: TopMenu.usersPath,
+                  waiter: UsersSearchPane.waitLoading,
+                });
+                UsersSearchPane.searchByKeywords(testData.user.username);
+                UsersSearchPane.openUser(testData.user.username);
+                UsersCard.openFeeFines();
+                UsersCard.startFeeFineAdding();
+                NewFeeFine.setFeeFineOwner(ownerBody.owner);
+                NewFeeFine.checkFilteredFeeFineType(manualCharge.feeFineType);
+                NewFeeFine.setFeeFineType(manualCharge.feeFineType);
+                NewFeeFine.chargeOnly();
+                UsersSearchPane.waitLoading();
+              });
+          });
+        });
+      });
+    });
+
+    after('Delete test data', () => {
+      UserEdit.changeServicePointPreferenceViaApi(testData.user.userId, [testData.servicePoint.id]);
+      ServicePoints.deleteViaApi(testData.servicePoint.id);
+      Users.deleteViaApi(testData.user.userId);
+      RefundReasons.deleteViaApi(testData.refundReason.id);
+      PaymentMethods.deleteViaApi(testData.paymentMethod.id);
+      ManualCharges.deleteViaApi(feeFineType.id);
+      UsersOwners.deleteViaApi(testData.ownerId);
+    });
+
+    it(
+      'C356793 Verify that library staff can cancel a fee/fine as an error for a patron if fee/fine has been fully paid and then fully refunded (vega) (TaaS)',
+      { tags: ['extendedPath', 'vega'] },
+      () => {
+        // Click on "Fees/fines" accordion
+        UsersCard.openFeeFines();
+        UsersCard.verifyOpenedFeeFines(1, feeFineType.amount);
+        // Click on " open fee/fine" link
+        UsersCard.showOpenedFeeFines();
+        UserAllFeesFines.verifyPageHeader(testData.user.username);
+        // Select created fee/fine and click "Pay" button
+        UserAllFeesFines.clickRowCheckbox(0);
+        UserAllFeesFines.paySelectedFeeFines();
+        UserAllFeesFines.verifyPayModalIsOpen();
+        PayFeeFine.checkAmount(feeFineType.amount);
+        // Select Payment method and click "Pay" button
+        PayFeeFine.setPaymentMethod(testData.paymentMethod);
+        // Click "Confirm" button
+        PayFeeFine.submitAndConfirm();
+        PayFeeFine.checkConfirmModalClosed();
+        UserAllFeesFines.verifyPageHeader(testData.user.username);
+        // Switch to "Closed" tab
+        UserAllFeesFines.openClosedFeesFines();
+        // Select just paid fee/fine and click "Refund" button
+        UserAllFeesFines.clickOnRowByIndex(0);
+        // Select Refund reason and click "Refund" button
+        UserAllFeesFines.refundSelectedFeeFines();
+        RefundFeeFine.waitLoading();
+        // Select Refund reason and click "Refund" button
+        RefundFeeFine.selectRefundReason(testData.refundReason.nameReason);
+        // Click "Refund" and "Confirm" button
+        RefundFeeFine.submitAndConfirm();
+        RefundFeeFine.verifyRefundSuccess(
+          `1 fee/fine for ${feeFineType.amount}.00 has been successfully fully refunded for `,
+        );
+        // Switch to "Open" tab
+        cy.visit(AppPaths.getOpenFeeFinePath(testData.user.userId));
+        // Select the just Refunded fee/fine, click on "..." button and select "Error" action
+        UserAllFeesFines.cancelSelectedFeeFines(0);
+        CancelFeeFine.waitLoading();
+        // Fill in "Additional information for staff*" field and click "Confirm" button
+        CancelFeeFine.fillInAdditionalInformationAndConfirm(getTestEntityValue('comment'));
+        UserAllFeesFines.openClosedFeesFines();
+        UserAllFeesFines.verifyPaymentStatus(0, 'Cancelled as error');
+      },
+    );
+  });
+});

--- a/cypress/support/fragments/users/cancelFeeFaine.js
+++ b/cypress/support/fragments/users/cancelFeeFaine.js
@@ -1,10 +1,20 @@
-import { Modal } from '../../../../interactors';
+import { including } from '@interactors/html';
+
+import { Modal, TextArea, Button, Callout } from '../../../../interactors';
 
 const rootModal = Modal({ id: 'error-modal' });
 
 export default {
   waitLoading: () => {
     cy.expect(rootModal.exists());
+  },
+
+  fillInAdditionalInformationAndConfirm: (comment) => {
+    cy.do([
+      rootModal.find(TextArea({ name: 'comment' })).fillIn(comment),
+      rootModal.find(Button('Confirm')).click(),
+    ]);
+    cy.expect(Callout(including('has been successfully cancelled as error for ')).exists());
   },
 
   cancelFeeFineViaApi: (apiBody, feeFineId) => cy.okapiRequest({

--- a/cypress/support/fragments/users/payFeeFaine.js
+++ b/cypress/support/fragments/users/payFeeFaine.js
@@ -23,6 +23,7 @@ export default {
   },
   submitAndConfirm: () => {
     cy.do(rootModal.find(Button({ id: 'submit-button' })).click());
+    cy.expect(confirmationModal.exists());
     cy.do(
       confirmationModal
         .find(Button({ id: matching('clickable-confirmation-[0-9]+-confirm') }))

--- a/cypress/support/fragments/users/refundFeeFine.js
+++ b/cypress/support/fragments/users/refundFeeFine.js
@@ -1,4 +1,12 @@
-import { Button, matching, Modal, Select, TextField, including } from '../../../../interactors';
+import {
+  Button,
+  Modal,
+  Select,
+  TextField,
+  Callout,
+  matching,
+  including,
+} from '../../../../interactors';
 
 const rootModal = Modal({ id: 'refund-modal' });
 const confirmationModal = Modal(including('Confirm fee/fine'));
@@ -18,6 +26,7 @@ export default {
         .click(),
     );
   },
+  verifyRefundSuccess: (successMsg) => cy.expect(Callout(including(successMsg)).exists()),
   refundFeeFineViaApi: (apiBody, feeFineId) => cy.okapiRequest({
     method: 'POST',
     path: `accounts/${feeFineId}/refund`,

--- a/cypress/support/fragments/users/userAllFeesFines.js
+++ b/cypress/support/fragments/users/userAllFeesFines.js
@@ -1,4 +1,4 @@
-import { CheckBox } from '@interactors/html';
+import { CheckBox, including } from '@interactors/html';
 
 import {
   Button,
@@ -8,6 +8,7 @@ import {
   MultiColumnList,
   MultiColumnListRow,
   MultiColumnListHeader,
+  MultiColumnListCell,
 } from '../../../../interactors';
 import ServicePoints from '../settings/tenant/servicePoints/servicePoints';
 import PaymentMethods from '../settings/users/paymentMethods';
@@ -62,6 +63,7 @@ export default {
     cy.do(Button({ id: 'open-closed-all-charge-button' }).click());
   },
   waitLoading: () => cy.expect(HTML('All fees/fines for ').exists()),
+  verifyPageHeader: (username) => cy.expect(HTML(including(`Fees/fines - ${username}`)).exists()),
   checkRowsAreChecked: (areRowsChecked) => {
     const beChecked = areRowsChecked ? 'be.checked' : 'not.be.checked';
 
@@ -108,6 +110,15 @@ export default {
   waiveSelectedFeeFines: () => {
     cy.do(Dropdown('Actions').choose('Waive'));
   },
+  refundSelectedFeeFines: () => cy.do(Dropdown('Actions').choose('Refund')),
+  cancelSelectedFeeFines: (rowIndex) => {
+    cy.do(
+      feeFinesList
+        .find(MultiColumnListRow({ index: rowIndex }))
+        .find(Dropdown())
+        .choose('Error'),
+    );
+  },
   clickPayEllipsis: (rowIndex) => {
     cy.do(
       feeFinesList
@@ -120,4 +131,13 @@ export default {
   verifyPayModalIsOpen: () => {
     cy.expect(Modal('Pay fee/fine').exists());
   },
+  verifyPaymentStatus: (rowIndex, status) => {
+    cy.expect(
+      feeFinesList
+        .find(MultiColumnListRow({ index: rowIndex }))
+        .find(MultiColumnListCell({ column: 'Payment status' }))
+        .has({ content: status }),
+    );
+  },
+  openClosedFeesFines: () => cy.do(Button({ id: 'closed-accounts' }).click()),
 };


### PR DESCRIPTION
[C356793](https://foliotest.testrail.io/index.php?/cases/view/356793)

[Allure Report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/5810/allure)

![Screenshot 2023-12-05 at 11 05 32 AM](https://github.com/folio-org/stripes-testing/assets/83753806/86465337-ec99-407b-b90c-45f92aed0e93)
