### PR TITLE
C365132 Verify that Bulk edit modal DOES NOT Start Bulk Edit (Local) from confirmation screen (firebird) (TaaS)

### DIFF
--- a/cypress/e2e/bulk-edit/csv/bulk-edit-csv-user-confirmation-screen.cy.js
+++ b/cypress/e2e/bulk-edit/csv/bulk-edit-csv-user-confirmation-screen.cy.js
@@ -1,0 +1,67 @@
+import TopMenu from '../../../support/fragments/topMenu';
+import permissions from '../../../support/dictionary/permissions';
+import BulkEditSearchPane from '../../../support/fragments/bulk-edit/bulk-edit-search-pane';
+import FileManager from '../../../support/utils/fileManager';
+import getRandomPostfix from '../../../support/utils/stringTools';
+import BulkEditActions from '../../../support/fragments/bulk-edit/bulk-edit-actions';
+import Users from '../../../support/fragments/users/users';
+
+let user;
+const userUUIDsFileName = `userUUIDs_${getRandomPostfix()}.csv`;
+const invalidUserUUID = getRandomPostfix();
+const matchedRecordsFileName = `Matched-Records-${userUUIDsFileName}`;
+const editedFileName = `edited-records-${getRandomPostfix()}.csv`;
+
+describe('bulk-edit', () => {
+  describe('csv approach', () => {
+    before('create test data', () => {
+      cy.createTempUser([
+        permissions.bulkEditCsvView.gui,
+        permissions.bulkEditCsvEdit.gui,
+        permissions.uiUserEdit.gui,
+      ]).then((userProperties) => {
+        user = userProperties;
+        cy.login(user.username, user.password, {
+          path: TopMenu.bulkEditPath,
+          waiter: BulkEditSearchPane.waitLoading,
+        });
+        FileManager.createFile(`cypress/fixtures/${userUUIDsFileName}`, user.userId);
+      });
+    });
+
+    after('delete test data', () => {
+      cy.getAdminToken();
+      FileManager.deleteFile(`cypress/fixtures/${userUUIDsFileName}`);
+      FileManager.deleteFile(`cypress/fixtures/${editedFileName}`);
+      FileManager.deleteFileFromDownloadsByMask(`*${matchedRecordsFileName}`);
+      Users.deleteViaApi(user.userId);
+    });
+
+    it(
+      'C365132 Verify that Bulk edit modal DOES NOT Start Bulk Edit (Local) from confirmation screen (firebird) (TaaS)',
+      { tags: ['extendedPath', 'firebird'] },
+      () => {
+        BulkEditSearchPane.checkUsersRadio();
+        BulkEditSearchPane.selectRecordIdentifier('User UUIDs');
+        BulkEditSearchPane.uploadFile(userUUIDsFileName);
+        BulkEditSearchPane.waitFileUploading();
+
+        const newName = `testName_${getRandomPostfix()}`;
+        BulkEditActions.downloadMatchedResults();
+        BulkEditActions.prepareValidBulkEditFile(
+          matchedRecordsFileName,
+          editedFileName,
+          'testPermFirst',
+          newName,
+        );
+        BulkEditActions.openStartBulkEditForm();
+        BulkEditSearchPane.uploadFile(editedFileName);
+        BulkEditSearchPane.waitFileUploading();
+        BulkEditActions.clickNext();
+        BulkEditActions.commitChanges();
+        BulkEditActions.openActions();
+        BulkEditActions.startBulkEditLocalAbsent();
+      },
+    );
+  });
+});

--- a/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
+++ b/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
@@ -65,6 +65,9 @@ export default {
   startBulkEditAbsent() {
     cy.expect(startBulkEditButton.absent());
   },
+  startBulkEditLocalAbsent() {
+    cy.expect(startBulkEditLocalButton.absent());
+  },
   closeBulkEditInAppForm() {
     cy.do(cancelBtn.click());
     cy.wait(1000);


### PR DESCRIPTION
https://foliotest.testrail.io/index.php?/cases/view/365132
![image](https://github.com/folio-org/stripes-testing/assets/153120768/f3007b84-9590-4c58-b525-ebc3ce3b8795)
