### PR TITLE
C350427 Check that the request has disappeared from the queue after changing the "Close-Cancelled" status (vega) (TaaS)

### DIFF
--- a/cypress/support/fragments/requests/requests.js
+++ b/cypress/support/fragments/requests/requests.js
@@ -579,6 +579,12 @@ export default {
     cy.do(requestsResultsSection.find(MultiColumnListRow({ index: 0 })).click());
   },
 
+  verifyRequestIsAbsent(barcode) {
+    cy.expect(
+      requestsResultsSection.find(MultiColumnListRow({ content: including(barcode) })).absent(),
+    );
+  },
+
   exportRequestToCsv: () => {
     cy.wait(1000);
     cy.do([actionsButtonInResultsPane.click(), exportSearchResultsToCsvOption.click()]);


### PR DESCRIPTION
[C350427](https://foliotest.testrail.io/index.php?/cases/view/350427)

[Allure Report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/6173/allure/)

![Screenshot 2023-12-20 at 5 46 14 PM](https://github.com/folio-org/stripes-testing/assets/83753806/d6616570-b5a7-46cc-bfb1-d9549bc0ee4b)
