### PR TITLE
C367955 Order field mapping profile: Check asterisks for required fields in existing field mapping profile (folijet) (TaaS)

### DIFF
--- a/cypress/e2e/data-import/settings/check-asterisk-in-existing-mapping-profile.cy.js
+++ b/cypress/e2e/data-import/settings/check-asterisk-in-existing-mapping-profile.cy.js
@@ -1,0 +1,80 @@
+import {
+  FOLIO_RECORD_TYPE,
+  ORDER_STATUSES,
+  VENDOR_NAMES,
+  ACQUISITION_METHOD_NAMES,
+  ORDER_FORMAT_NAMES_IN_PROFILE,
+} from '../../../support/constants';
+import SettingsMenu from '../../../support/fragments/settingsMenu';
+import FieldMappingProfiles from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfiles';
+import NewFieldMappingProfile from '../../../support/fragments/data_import/mapping_profiles/newFieldMappingProfile';
+import getRandomPostfix from '../../../support/utils/stringTools';
+import Users from '../../../support/fragments/users/users';
+import { Permissions } from '../../../support/dictionary';
+import SettingsMappingProfiles from '../../../support/fragments/settings/dataImport/settingsMappingProfiles';
+import FieldMappingProfileView from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfileView';
+import FieldMappingProfileEdit from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfileEdit';
+
+describe('data-import', () => {
+  describe('Settings', () => {
+    const testData = {};
+    const mappingProfile = {
+      name: `C367955testMappingProfile.${getRandomPostfix()}`,
+      typeValue: FOLIO_RECORD_TYPE.ORDER,
+      orderStatus: ORDER_STATUSES.OPEN,
+      vendor: VENDOR_NAMES.GOBI,
+      title: '245$a',
+      acquisitionMethod: ACQUISITION_METHOD_NAMES.PURCHASE_AT_VENDOR_SYSTEM,
+      orderFormat: ORDER_FORMAT_NAMES_IN_PROFILE.OTHER,
+      receivingWorkflow: 'Synchronized',
+      currency: 'USD',
+    };
+
+    before('login', () => {
+      cy.createTempUser([Permissions.settingsDataImportEnabled.gui]).then((userProperties) => {
+        testData.user = userProperties;
+
+        cy.login(testData.user.username, testData.user.password, {
+          path: SettingsMenu.mappingProfilePath,
+          waiter: FieldMappingProfiles.waitLoading,
+        });
+        FieldMappingProfiles.openNewMappingProfileForm();
+        NewFieldMappingProfile.fillOrderMappingProfile(mappingProfile);
+        NewFieldMappingProfile.save();
+      });
+    });
+
+    after('Delete test data', () => {
+      cy.getAdminToken();
+      Users.deleteViaApi(testData.user.userId);
+      FieldMappingProfiles.getFieldMappingProfileInDataImport({
+        query: `"name"=="${mappingProfile.name}"`,
+      }).then((response) => {
+        SettingsMappingProfiles.deleteMappingProfileApi(response.id);
+      });
+    });
+
+    it(
+      'C367955 Order field mapping profile: Check asterisks for required fields in existing field mapping profile (folijet) (TaaS)',
+      { tags: ['extendedPath', 'folijet'] },
+      () => {
+        // #1 Go to "Settings" application -> "Data import" -> Find field mapping profile from preconditions -> Click on profile from preconditions -> "Actions" -> "Edit"
+        cy.visit(SettingsMenu.mappingProfilePath);
+        FieldMappingProfiles.search(mappingProfile.name);
+        FieldMappingProfileView.edit();
+        FieldMappingProfileEdit.verifyScreenName(mappingProfile.name);
+        // #2 Check that required fields have red asterisk after the field label
+        NewFieldMappingProfile.verifyFieldsMarkedWithAsterisks([
+          { label: 'Purchase order status', conditions: { required: true } },
+          { label: 'Vendor', conditions: { required: true } },
+          { label: 'Order type', conditions: { required: true } },
+          { label: 'Title', conditions: { required: true } },
+          { label: 'Acquisition method', conditions: { required: true } },
+          { label: 'Order format', conditions: { required: true } },
+          { label: 'Receiving workflow', conditions: { required: true } },
+          { label: 'Currency', conditions: { required: true } },
+        ]);
+      },
+    );
+  });
+});

--- a/cypress/e2e/data-import/settings/check-asterisk-in-existing-mapping-profile.cy.js
+++ b/cypress/e2e/data-import/settings/check-asterisk-in-existing-mapping-profile.cy.js
@@ -11,9 +11,9 @@ import NewFieldMappingProfile from '../../../support/fragments/data_import/mappi
 import getRandomPostfix from '../../../support/utils/stringTools';
 import Users from '../../../support/fragments/users/users';
 import { Permissions } from '../../../support/dictionary';
-import SettingsMappingProfiles from '../../../support/fragments/settings/dataImport/settingsMappingProfiles';
 import FieldMappingProfileView from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfileView';
 import FieldMappingProfileEdit from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfileEdit';
+import FieldMappingProfilesSettings from '../../../support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfiles';
 
 describe('data-import', () => {
   describe('Settings', () => {
@@ -50,7 +50,7 @@ describe('data-import', () => {
       FieldMappingProfiles.getFieldMappingProfileInDataImport({
         query: `"name"=="${mappingProfile.name}"`,
       }).then((response) => {
-        SettingsMappingProfiles.deleteMappingProfileApi(response.id);
+        FieldMappingProfilesSettings.deleteMappingProfileViaApi(response.id);
       });
     });
 

--- a/cypress/support/fragments/data_import/mapping_profiles/fieldMappingProfiles.js
+++ b/cypress/support/fragments/data_import/mapping_profiles/fieldMappingProfiles.js
@@ -137,4 +137,15 @@ export default {
       }).exists(),
     );
   },
+  getFieldMappingProfileInDataImport: (searchParams) => {
+    return cy
+      .okapiRequest({
+        path: 'data-import-profiles/mappingProfiles',
+        searchParams,
+        isDefaultSearchParamsRequired: false,
+      })
+      .then((response) => {
+        return response.body.mappingProfiles[0];
+      });
+  },
 };


### PR DESCRIPTION
[TestRail](https://foliotest.testrail.io/index.php?/cases/view/367955)
[Allure Report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/6329/allure/)
![image](https://github.com/folio-org/stripes-testing/assets/147595219/9e5de1d7-74bb-4653-8df6-d742652ade5a)
