### PR TITLE
C380506-C380508 Order field mapping profile: Create Inventory physical resource fields are inactivated when Electronic order format is selected (folijet) (TaaS)

### DIFF
--- a/cypress/e2e/data-import/settings/verify-create-inventory-physical-inactive-in-electronic-order.cy.js
+++ b/cypress/e2e/data-import/settings/verify-create-inventory-physical-inactive-in-electronic-order.cy.js
@@ -1,0 +1,261 @@
+import {
+  FOLIO_RECORD_TYPE,
+  ORDER_STATUSES,
+  VENDOR_NAMES,
+  ACQUISITION_METHOD_NAMES,
+  ORDER_FORMAT_NAMES_IN_PROFILE,
+} from '../../../support/constants';
+import SettingsMenu from '../../../support/fragments/settingsMenu';
+import FieldMappingProfiles from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfiles';
+import FieldMappingProfilesSettings from '../../../support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfiles.js';
+import NewFieldMappingProfile from '../../../support/fragments/data_import/mapping_profiles/newFieldMappingProfile';
+import getRandomPostfix from '../../../support/utils/stringTools';
+import Users from '../../../support/fragments/users/users';
+import { Permissions } from '../../../support/dictionary';
+import FieldMappingProfileView from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfileView';
+import FieldMappingProfileEdit from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfileEdit';
+
+describe('data-import', () => {
+  describe('Settings', () => {
+    const testData = {};
+    const mappingProfileC380506 = {
+      name: `C380506testMappingProfile.${getRandomPostfix()}`,
+      typeValue: FOLIO_RECORD_TYPE.ORDER,
+      orderStatus1: ORDER_STATUSES.PENDING,
+      orderStatus2: ORDER_STATUSES.OPEN,
+      orderFormat1: '"Electronic Resource"',
+      orderFormat2: '"Physical Resource"',
+      incomingRecordType: 'MARC_BIBLIOGRAPHIC',
+      recordType: 'ORDER',
+      description: '',
+    };
+    const mappingProfileC380508 = {
+      name: `C380508testMappingProfile.${getRandomPostfix()}`,
+      typeValue: FOLIO_RECORD_TYPE.ORDER,
+      orderStatus: ORDER_STATUSES.PENDING,
+      orderFormat1: '"Electronic Resource"',
+      orderFormat2: '"Physical Resource"',
+      vendor: VENDOR_NAMES.GOBI,
+      title: '245$a',
+      acquisitionMethod: ACQUISITION_METHOD_NAMES.PURCHASE_AT_VENDOR_SYSTEM,
+      orderFormat: ORDER_FORMAT_NAMES_IN_PROFILE.PE_MIX,
+      receivingWorkflow: 'Synchronized',
+      createInventoryElectronic: '"Instance"',
+      currency: 'USD',
+      incomingRecordType: 'MARC_BIBLIOGRAPHIC',
+      recordType: 'ORDER',
+      description: '',
+      orderStatus2: ORDER_STATUSES.OPEN,
+    };
+    const physicalResourceAccordionName = 'Physical resource details';
+    const orderFormatField = {
+      accordion: 'PO line details',
+      fieldName: 'Order format*',
+    };
+    const costDetailsFields = [
+      {
+        accordion: 'Cost details',
+        fieldName: 'Physical unit price',
+      },
+      {
+        accordion: 'Cost details',
+        fieldName: 'Quantity physical',
+      },
+    ];
+    const physicalResourceFields = [
+      {
+        accordion: 'Physical resource details',
+        fieldName: 'Material supplier',
+      },
+      {
+        accordion: 'Physical resource details',
+        fieldName: 'Receipt due',
+      },
+      {
+        accordion: 'Physical resource details',
+        fieldName: 'Expected receipt date',
+      },
+      {
+        accordion: 'Physical resource details',
+        fieldName: 'Create inventory',
+      },
+      {
+        accordion: 'Physical resource details',
+        fieldName: 'Material type',
+      },
+    ];
+    const locationFields = {
+      quantityPhysical: {
+        accordion: 'Location',
+        fieldName: 'Quantity physical',
+      },
+    };
+
+    before('Create test data', () => {
+      cy.createTempUser([Permissions.settingsDataImportEnabled.gui]).then((userProperties) => {
+        testData.user = userProperties;
+        cy.login(testData.user.username, testData.user.password, {
+          path: SettingsMenu.mappingProfilePath,
+          waiter: FieldMappingProfiles.waitLoading,
+        });
+      });
+    });
+
+    after('Delete test data', () => {
+      cy.getAdminToken();
+      Users.deleteViaApi(testData.user.userId);
+      FieldMappingProfiles.getFieldMappingProfileInDataImport({
+        query: `"name"=="${mappingProfileC380508.name}"`,
+      }).then((response) => {
+        FieldMappingProfilesSettings.deleteMappingProfileViaApi(response.id);
+      });
+    });
+
+    it(
+      'C380506 Order field mapping profile: "Create Inventory" physical resource fields are inactivated when Electronic order format is selected on Create screen (folijet) (TaaS)',
+      { tags: ['extendedPath', 'folijet'] },
+      () => {
+        // #1 Select "Field mapping profiles" -> Click "Actions" button -> Select "New field mapping profile" option
+        FieldMappingProfiles.openNewMappingProfileForm();
+
+        // #2 Fill in the following fields
+        NewFieldMappingProfile.fillSummaryInMappingProfile(mappingProfileC380506);
+        NewFieldMappingProfile.fillPurchaseOrderStatus(mappingProfileC380506.orderStatus1);
+        NewFieldMappingProfile.fillOrderFormat(mappingProfileC380506.orderFormat1);
+        NewFieldMappingProfile.checkPreviouslyPopulatedDataIsDisplayed(mappingProfileC380506);
+
+        // #3 Navigate to the "Physical unit price" and "Quantity physical" fields in "Cost details" accordion
+        costDetailsFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+
+        // #4 Navigate to the "Physical resource details" accordion
+        physicalResourceFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+        NewFieldMappingProfile.verifyOrganizationLookUpButtonDisabled('Physical resource details');
+        NewFieldMappingProfile.verifyAddVolumeButtonDisabled();
+
+        // #5 Click "Add location" button -> Check "Quantity physical" field
+        NewFieldMappingProfile.clickAddLocationButton();
+        NewFieldMappingProfile.verifyRowFieldEmptyAndDisabled(
+          0,
+          locationFields.quantityPhysical.accordion,
+          locationFields.quantityPhysical.fieldName,
+        );
+
+        // #6 Return to the "Order format" field -> Change the value to the "Physical resource" option
+        NewFieldMappingProfile.fillOrderFormat(mappingProfileC380506.orderFormat2);
+        NewFieldMappingProfile.verifyFieldValue(
+          orderFormatField.accordion,
+          orderFormatField.fieldName,
+          mappingProfileC380506.orderFormat2,
+        );
+
+        // #7 Change "Order format" field one more time to the "Electronic resource" option
+        NewFieldMappingProfile.fillOrderFormat(mappingProfileC380506.orderFormat1);
+        NewFieldMappingProfile.verifyFieldValue(
+          orderFormatField.accordion,
+          orderFormatField.fieldName,
+          mappingProfileC380508.orderFormat1,
+        );
+
+        // #8 Repeat steps 3-5
+        costDetailsFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+        physicalResourceFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+        NewFieldMappingProfile.clickAddLocationButton();
+        NewFieldMappingProfile.verifyRowFieldEmptyAndDisabled(
+          1,
+          locationFields.quantityPhysical.accordion,
+          locationFields.quantityPhysical.fieldName,
+        );
+
+        // After test: Close editor window
+        NewFieldMappingProfile.clickClose();
+        NewFieldMappingProfile.confirmCloseWithoutSaving();
+        FieldMappingProfiles.waitLoading();
+      },
+    );
+
+    it(
+      'C380508 Order field mapping profile: "Create Inventory" physical resource fields are inactivated when Electronic order format is selected on Edit screen (folijet) (TaaS)',
+      { tags: ['extendedPath', 'folijet'] },
+      () => {
+        // #1 Select "Field mapping profiles" -> Click "Actions" button -> Select "New field mapping profile" option
+        FieldMappingProfiles.openNewMappingProfileForm();
+
+        // #2 Populate the following fields:
+        NewFieldMappingProfile.fillOrderMappingProfile(mappingProfileC380508);
+        NewFieldMappingProfile.fillOrderFormat(mappingProfileC380508.orderFormat1);
+        NewFieldMappingProfile.fillCreateInventoryForElectronicResource(
+          mappingProfileC380508.createInventoryElectronic,
+        );
+        NewFieldMappingProfile.checkPreviouslyPopulatedDataIsDisplayed(mappingProfileC380508);
+
+        // #3 Click "Save as profile & Close" button
+        NewFieldMappingProfile.save();
+        FieldMappingProfileView.checkCalloutMessage('New record created:');
+
+        // #4 Click "Action" button in the top right corner of the detail view page -> Select "Edit" option
+        FieldMappingProfileView.edit();
+        FieldMappingProfileEdit.verifyScreenName(mappingProfileC380508.name);
+
+        // #5 Navigate to the "Physical unit price" and "Quantity physical" fields in "Cost details" accordion
+        costDetailsFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+
+        // #6 Navigate to the "Physical resource details" accordion
+        physicalResourceFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+        NewFieldMappingProfile.verifyOrganizationLookUpButtonDisabled(
+          physicalResourceAccordionName,
+        );
+        NewFieldMappingProfile.verifyAddVolumeButtonDisabled();
+
+        // #7 Click "Add location" button -> Check "Quantity physical" field
+        NewFieldMappingProfile.clickAddLocationButton();
+        NewFieldMappingProfile.verifyRowFieldEmptyAndDisabled(
+          0,
+          locationFields.quantityPhysical.accordion,
+          locationFields.quantityPhysical.fieldName,
+        );
+
+        // #8 Navigate to the "Order format" field -> Change the value to the "Physical resource" option
+        NewFieldMappingProfile.fillOrderFormat(mappingProfileC380508.orderFormat2);
+        NewFieldMappingProfile.verifyFieldValue(
+          orderFormatField.accordion,
+          orderFormatField.fieldName,
+          mappingProfileC380508.orderFormat2,
+        );
+
+        // #9 Change "Order format" field one more time to the "Electronic resource" option
+        NewFieldMappingProfile.fillOrderFormat(mappingProfileC380508.orderFormat1);
+        NewFieldMappingProfile.verifyFieldValue(
+          orderFormatField.accordion,
+          orderFormatField.fieldName,
+          mappingProfileC380508.orderFormat1,
+        );
+
+        // #10 Repeat steps 5-7
+        costDetailsFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+        physicalResourceFields.forEach(({ accordion, fieldName }) => {
+          NewFieldMappingProfile.verifyFieldEmptyAndDisabled(accordion, fieldName);
+        });
+        NewFieldMappingProfile.clickAddLocationButton();
+        NewFieldMappingProfile.verifyRowFieldEmptyAndDisabled(
+          1,
+          locationFields.quantityPhysical.accordion,
+          locationFields.quantityPhysical.fieldName,
+        );
+      },
+    );
+  });
+});

--- a/cypress/e2e/data-import/settings/verify-create-inventory-physical-inactive-in-electronic-order.cy.js
+++ b/cypress/e2e/data-import/settings/verify-create-inventory-physical-inactive-in-electronic-order.cy.js
@@ -7,7 +7,7 @@ import {
 } from '../../../support/constants';
 import SettingsMenu from '../../../support/fragments/settingsMenu';
 import FieldMappingProfiles from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfiles';
-import FieldMappingProfilesSettings from '../../../support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfiles.js';
+import FieldMappingProfilesSettings from '../../../support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfiles';
 import NewFieldMappingProfile from '../../../support/fragments/data_import/mapping_profiles/newFieldMappingProfile';
 import getRandomPostfix from '../../../support/utils/stringTools';
 import Users from '../../../support/fragments/users/users';

--- a/cypress/e2e/data-import/settings/verify-create-inventory-physical-inactive-in-electronic-order.cy.js
+++ b/cypress/e2e/data-import/settings/verify-create-inventory-physical-inactive-in-electronic-order.cy.js
@@ -7,7 +7,6 @@ import {
 } from '../../../support/constants';
 import SettingsMenu from '../../../support/fragments/settingsMenu';
 import FieldMappingProfiles from '../../../support/fragments/data_import/mapping_profiles/fieldMappingProfiles';
-import FieldMappingProfilesSettings from '../../../support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfiles';
 import NewFieldMappingProfile from '../../../support/fragments/data_import/mapping_profiles/newFieldMappingProfile';
 import getRandomPostfix from '../../../support/utils/stringTools';
 import Users from '../../../support/fragments/users/users';
@@ -104,11 +103,7 @@ describe('data-import', () => {
     after('Delete test data', () => {
       cy.getAdminToken();
       Users.deleteViaApi(testData.user.userId);
-      FieldMappingProfiles.getFieldMappingProfileInDataImport({
-        query: `"name"=="${mappingProfileC380508.name}"`,
-      }).then((response) => {
-        FieldMappingProfilesSettings.deleteMappingProfileViaApi(response.id);
-      });
+      FieldMappingProfileView.deleteViaApi(mappingProfileC380508.name);
     });
 
     it(
@@ -157,7 +152,7 @@ describe('data-import', () => {
         NewFieldMappingProfile.verifyFieldValue(
           orderFormatField.accordion,
           orderFormatField.fieldName,
-          mappingProfileC380508.orderFormat1,
+          mappingProfileC380506.orderFormat1,
         );
 
         // #8 Repeat steps 3-5

--- a/cypress/support/fragments/data_import/mapping_profiles/newFieldMappingProfile.js
+++ b/cypress/support/fragments/data_import/mapping_profiles/newFieldMappingProfile.js
@@ -21,6 +21,7 @@ import {
   IconButton,
   Popover,
   Label,
+  ListItem,
 } from '../../../../../interactors';
 import getRandomPostfix from '../../../utils/stringTools';
 import {
@@ -656,11 +657,12 @@ export default {
   fillQuantity: (quantity) => cy.do(TextField('Quantity*').fillIn(quantity)),
   fillSubTotal: (number) => cy.do(TextField('Sub-total*').fillIn(number)),
   fillPurchaseOrderStatus: (orderStatus) => cy.do(purchaseOrderStatus.fillIn(`"${orderStatus}"`)),
-  fillCreateInventoryForPhysicalResource: (inventory) => {
-    cy.do(physicalResourceDetailsAccordion.find(TextField('Create inventory')).fillIn(inventory));
-  },
   fillCreateInventoryForElectronicResource: (inventory) => {
     cy.do(eResourcesDetailsAccordion.find(TextField('Create inventory')).fillIn(inventory));
+  },
+  fillOrderFormat: (format) => cy.do(orderFormatField.fillIn(format)),
+  fillCreateInventoryForPhysicalResource: (inventory) => {
+    cy.do(physicalResourceDetailsAccordion.find(TextField('Create inventory')).fillIn(inventory));
   },
 
   fillMappingProfileForUpdatesMarc: (specialMappingProfile = defaultMappingProfile) => {
@@ -1203,6 +1205,16 @@ export default {
     cy.expect(Popover({ content: including(message) }).exists());
   },
 
+  verifyInfoIconClickable: (accordionName, fieldLabel) => {
+    cy.do(
+      Accordion(accordionName)
+        .find(Label(fieldLabel))
+        .find(IconButton({ icon: 'info' }))
+        .click(),
+    );
+    cy.expect(Popover().exists());
+  },
+
   verifyFieldValue: (accordionName, fieldName, value) => {
     cy.expect(Accordion(accordionName).find(TextField(fieldName)).has({ value }));
   },
@@ -1240,14 +1252,25 @@ export default {
     purchaseOrderStatus.has({ focused: value });
   },
 
-  verifyInfoIconClickable: (accordionName, fieldLabel) => {
-    cy.do(
+  verifyRowFieldEmptyAndDisabled: (rowIndex, accordionName, fieldName) => {
+    cy.expect(
       Accordion(accordionName)
-        .find(Label(fieldLabel))
-        .find(IconButton({ icon: 'info' }))
-        .click(),
+        .find(ListItem({ index: rowIndex }))
+        .find(TextField(fieldName))
+        .has({ value: '', disabled: true }),
     );
-    cy.expect(Popover().exists());
+  },
+
+  verifyAddVolumeButtonDisabled: () => {
+    cy.expect(physicalResourceDetailsAccordion.find(Button('Add volume')).has({ disabled: true }));
+  },
+
+  verifyOrganizationLookUpButtonDisabled: (accordionName) => {
+    cy.expect(Accordion(accordionName).find(organizationLookUpButton).has({ disabled: true }));
+  },
+
+  clickAddLocationButton: () => {
+    cy.do([locationAccordion.find(Button('Add location')).click()]);
   },
 
   verifyDefaultPurchaseOrderLinesLimit(value) {


### PR DESCRIPTION
[testRail - C380506](https://foliotest.testrail.io/index.php?/cases/view/380506)
[testRail - C380508](https://foliotest.testrail.io/index.php?/cases/view/380508)
[AllureReport](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/6400/allure/)
![image](https://github.com/folio-org/stripes-testing/assets/147595219/5dddc248-ae8f-4ecc-9c83-1b0673d1f745)