### PR TITLE
[378896] Provider fields can be manually cleared/edited (folijet) (TaaS)

### DIFF
--- a/cypress/e2e/settings/data-import/check-contributor-type-mappings.cy.js
+++ b/cypress/e2e/settings/data-import/check-contributor-type-mappings.cy.js
@@ -33,7 +33,7 @@ describe('Data Import', () => {
         },
         orderInformation: {
           status: ORDER_STATUSES.PENDING,
-          vendor: 'GOBI Library Solutions',
+          organizationLookUp: 'GOBI Library Solutions',
         },
         orderLineInformation: {
           title: orderLineTitle,

--- a/cypress/e2e/settings/data-import/check-provider-fields-can-be-manually-updated.cy.js
+++ b/cypress/e2e/settings/data-import/check-provider-fields-can-be-manually-updated.cy.js
@@ -1,0 +1,110 @@
+import { Permissions } from '../../../support/dictionary';
+import { ORDER_STATUSES } from '../../../support/constants';
+import {
+  SettingsDataImport,
+  FieldMappingProfiles,
+  FieldMappingProfileView,
+} from '../../../support/fragments/settings/dataImport';
+import { SETTINGS_TABS } from '../../../support/fragments/settings/dataImport/settingsDataImport';
+import SettingsMenu from '../../../support/fragments/settingsMenu';
+import Users from '../../../support/fragments/users/users';
+import getRandomPostfix from '../../../support/utils/stringTools';
+
+describe('Data Import', () => {
+  describe('Settings', () => {
+    const mappingProfileName = `autotest_mapping_profile_name_${getRandomPostfix()}`;
+    const testData = {
+      mappingProfile: {
+        summary: {
+          name: mappingProfileName,
+          incomingRecordType: 'MARC Bibliographic',
+          existingRecordType: 'Order',
+        },
+        orderInformation: {
+          status: ORDER_STATUSES.PENDING,
+          organizationLookUp: 'GOBI Library Solutions',
+        },
+        orderLineInformation: {
+          title: '245$a',
+          poLineDetails: {
+            acquisitionMethod: 'Other',
+            orderFormat: 'P/E Mix',
+            receivingWorkflow: 'Synchronized',
+          },
+          costDetails: {
+            physicalUnitPrice: '1.00',
+            currency: 'USD',
+          },
+          physicalResourceDetails: {
+            organizationLookUp: 'Otto Harrassowitz GmbH & Co. KG',
+          },
+          eResourceDetails: {
+            organizationLookUp: 'EBSCO SUBSCRIPTION SERVICES',
+          },
+        },
+      },
+      user: {},
+    };
+
+    before('Create test data', () => {
+      cy.createTempUser([Permissions.settingsDataImportEnabled.gui]).then((userProperties) => {
+        testData.user = userProperties;
+
+        cy.login(testData.user.username, testData.user.password, {
+          path: SettingsMenu.dataImportSettingsPath,
+          waiter: SettingsDataImport.waitLoading,
+        });
+      });
+    });
+
+    after('Delete test data', () => {
+      cy.getAdminToken().then(() => {
+        FieldMappingProfiles.deleteMappingProfileByNameViaApi(mappingProfileName);
+        Users.deleteViaApi(testData.user.userId);
+      });
+    });
+
+    it(
+      'C378896 Order field mapping: Confirm Vendor/Material supplier/Access provider fields can be manually cleared/edited (folijet) (TaaS)',
+      { tags: ['extendedPath', 'folijet'] },
+      () => {
+        // Go to Settings application-> Data import-> Field mapping profiles
+        SettingsDataImport.selectSettingsTab(SETTINGS_TABS.FIELD_MAPPING_PROFILE);
+
+        // Click Actions button, Select New field mapping profile
+        const FieldMappingProfileEditForm =
+          FieldMappingProfiles.clickCreateNewFieldMappingProfile();
+
+        // Fill mapping profile fields
+        FieldMappingProfileEditForm.fillMappingProfileFields({ ...testData.mappingProfile });
+
+        // Click "Save as profile & Close" button
+        FieldMappingProfileEditForm.clickSaveAndCloseButton();
+
+        // Click "Actions" button, Select "Edit" option
+        FieldMappingProfileView.clickEditButton();
+
+        // Change fields manually
+        FieldMappingProfileEditForm.fillMappingProfileFields({
+          orderInformation: { vendor: '970$a' },
+          orderLineInformation: {
+            physicalResourceDetails: { materialSupplier: '970$b' },
+            eResourceDetails: { accessProvider: '970$c' },
+          },
+        });
+
+        // Click "Save as profile & Close" button
+        FieldMappingProfileEditForm.clickSaveAndCloseButton();
+
+        // Check "Vendor", "Material Supplier" and "Access provider" fields
+        FieldMappingProfileView.checkOrderFieldsConditions([
+          { label: 'Vendor', conditions: { value: '"970$a"' } },
+        ]);
+        FieldMappingProfileView.checkOrderLineFieldsConditions([
+          { label: 'Material supplier', conditions: { value: '"970$b"' } },
+          { label: 'Access provider', conditions: { value: '"970$c"' } },
+        ]);
+      },
+    );
+  });
+});

--- a/cypress/support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfileView.js
+++ b/cypress/support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfileView.js
@@ -41,6 +41,20 @@ const invoiceDetailsViews = {
   invoiceLineAdjustments: detailsSection.find(Section({ id: 'view-invoice-line-adjustments' })),
 };
 
+const orderDetailsViews = {
+  orderInformation: detailsSection.find(Section({ id: 'view-order-information' })),
+  orderLineInformation: detailsSection.find(Section({ id: 'view-order-line-information' })),
+  // order line info sub sections
+  itemDetails: detailsSection.find(Section({ id: 'view-item-details' })),
+  poLineDetails: detailsSection.find(Section({ id: 'view-po-line-details' })),
+  vendorDetails: detailsSection.find(Section({ id: 'view-vendor' })),
+  costDetails: detailsSection.find(Section({ id: 'view-cost-details' })),
+  fundDistributionDetails: detailsSection.find(Section({ id: 'view-fund-distribution' })),
+  orderLocationDetails: detailsSection.find(Section({ id: 'view-order-location' })),
+  pResourceDetails: detailsSection.find(Section({ id: 'view-physical-resource-details' })),
+  eResourceDetails: detailsSection.find(Section({ id: 'view-e-resources-details' })),
+};
+
 const actionsButton = mappingProfileView.find(Button('Actions'));
 
 export default {
@@ -69,6 +83,12 @@ export default {
   },
   checkSummaryFieldsConditions(fields = []) {
     this.checkFieldsConditions({ fields, section: summarySection });
+  },
+  checkOrderFieldsConditions(fields = []) {
+    this.checkFieldsConditions({ fields, section: orderDetailsViews.orderInformation });
+  },
+  checkOrderLineFieldsConditions(fields = []) {
+    this.checkFieldsConditions({ fields, section: orderDetailsViews.orderLineInformation });
   },
   checkAdminDataFieldsConditions(fields = []) {
     this.checkFieldsConditions({ fields, section: adminDataSection });


### PR DESCRIPTION
[C378896](https://foliotest.testrail.io/index.php?/cases/view/378896)
***
[Allure report](https://jenkins-aws.indexdata.com/job/folioRancher/job/folioTestingTools/job/runCypressTests/6409/allure)
***

<img width="847" alt="Screenshot 2023-12-28 at 13 43 44" src="https://github.com/folio-org/stripes-testing/assets/16187978/96d657b4-63ec-4e6b-ac63-0b1d7a817969">
