### PR TITLE
Poppy C375256 fix

### DIFF
--- a/cypress/e2e/inventory/search/search-in-inventory-linked.cy.js
+++ b/cypress/e2e/inventory/search/search-in-inventory-linked.cy.js
@@ -97,7 +97,7 @@ describe('Search in Inventory', () => {
         InventoryInstance.searchResults(marcFiles[1].authorityHeading);
         MarcAuthorities.checkFieldAndContentExistence(
           testData.tag010,
-          `$a ${marcFiles[1].authority010FieldValue}`,
+          `‡a ${marcFiles[1].authority010FieldValue}`,
         );
         InventoryInstance.clickLinkButton();
         QuickMarcEditor.verifyAfterLinkingAuthority(testData.tag130);
@@ -113,7 +113,7 @@ describe('Search in Inventory', () => {
         InventoryInstance.searchResults(marcFiles[2].authorityHeading);
         MarcAuthorities.checkFieldAndContentExistence(
           testData.tag010,
-          `$a ${marcFiles[2].authority010FieldValue}`,
+          `‡a ${marcFiles[2].authority010FieldValue}`,
         );
         InventoryInstance.clickLinkButton();
         QuickMarcEditor.verifyAfterLinkingAuthority(testData.tag240);


### PR DESCRIPTION
"$" was updated to "‡" in MARC record source view for C375256 test 
![image](https://github.com/folio-org/stripes-testing/assets/88427701/2e69295b-403e-44d0-a339-de5dd4119436)
