### PR TITLE
Spitfire Poppy minor fixes

### DIFF
--- a/cypress/e2e/inventory/search/browse-subjects-linked.cy.js
+++ b/cypress/e2e/inventory/search/browse-subjects-linked.cy.js
@@ -77,7 +77,7 @@ describe('inventory', () => {
           InventoryInstance.searchResults(testData.subjectName);
           MarcAuthorities.checkFieldAndContentExistence(
             testData.tag010,
-            `$a ${marcFiles[1].naturalId}`,
+            `‡a ${marcFiles[1].naturalId}`,
           );
           InventoryInstance.clickLinkButton();
           QuickMarcEditor.verifyAfterLinkingAuthority(testData.tag610);

--- a/cypress/e2e/marc/marc-hodings/create-new-marc-holdings.cy.js
+++ b/cypress/e2e/marc/marc-hodings/create-new-marc-holdings.cy.js
@@ -170,7 +170,7 @@ describe('MARC -> MARC Holdings', () => {
         // "Edit in quickMARC" option might not be active immediately after creating MARC Holdings
         // this option becomes active after reopening Holdings view window
         HoldingsRecordView.close();
-        InventoryInstance.openHoldingView();
+        InventoryInstance.openHoldingViewByID(holdingsID);
 
         HoldingsRecordView.editInQuickMarc();
         QuickMarcEditor.waitLoading();
@@ -203,7 +203,7 @@ describe('MARC -> MARC Holdings', () => {
       HoldingsRecordView.getHoldingsIDInDetailView().then((holdingsID) => {
         recordIDs.push(holdingsID);
         HoldingsRecordView.close();
-        InventoryInstance.openHoldingView();
+        InventoryInstance.openHoldingViewByID(holdingsID);
         HoldingsRecordView.viewSource();
         HoldingsRecordView.closeSourceView();
         InventoryInstance.verifyLastUpdatedDate();
@@ -239,7 +239,7 @@ describe('MARC -> MARC Holdings', () => {
       HoldingsRecordView.getHoldingsIDInDetailView().then((holdingsID) => {
         recordIDs.push(holdingsID);
         HoldingsRecordView.close();
-        InventoryInstance.openHoldingView();
+        InventoryInstance.openHoldingViewByID(holdingsID);
         HoldingsRecordView.viewSource();
         InventoryViewSource.checkFieldContentMatch(
           testData.tag001,


### PR DESCRIPTION
Minor fixes for two test suites:

- using `openHoldingViewByID` method instead of a default one for test to not fail when multiple holdings found
- updated source view subfield marker symbol