### PR TITLE
FAT-12856 Fix Thunderjet tests for eureka

### DIFF
--- a/cypress/e2e/invoices/FY-appears-after-fund-distribution-change-when-FY-was-undefined.cy.js
+++ b/cypress/e2e/invoices/FY-appears-after-fund-distribution-change-when-FY-was-undefined.cy.js
@@ -64,9 +64,8 @@ describe('Invoices', () => {
   let location;
 
   before(() => {
-    cy.getAdminToken();
     cy.loginAsAdmin();
-
+    cy.getAdminToken();
     Organizations.createOrganizationViaApi(organization).then((responseOrganizations) => {
       organization.id = responseOrganizations;
       invoice.accountingCode = organization.erpCode;
@@ -85,6 +84,7 @@ describe('Invoices', () => {
             firstFund.id = firstFundResponse.fund.id;
 
             cy.loginAsAdmin({ path: TopMenu.fundPath, waiter: Funds.waitLoading });
+            cy.getAdminToken();
             FinanceHelp.searchByName(firstFund.name);
             Funds.selectFund(firstFund.name);
             Funds.addBudget(allocatedQuantity);

--- a/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FY-order.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FY-order.cy.js
@@ -71,6 +71,7 @@ describe('Invoices', () => {
     cy.loginAsAdmin();
     cy.visit(SettingsMenu.expenseClassesPath);
     SettingsFinance.createNewExpenseClass(firstExpenseClass);
+    cy.getAdminToken();
     FiscalYears.createViaApi(firstFiscalYear).then((firstFiscalYearResponse) => {
       firstFiscalYear.id = firstFiscalYearResponse.id;
       defaultLedger.fiscalYearOneId = firstFiscalYear.id;

--- a/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FY-order.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FY-order.cy.js
@@ -226,6 +226,7 @@ describe('Invoices', () => {
       organization.status = 'Active';
       Organizations.editOrganization();
       Organizations.changeOrganizationStatus(organization.status);
+      Organizations.waitLoading();
 
       cy.visit(TopMenu.invoicesPath);
       Invoices.searchByNumber(invoice.invoiceNumber);

--- a/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FYwhen-POL-created-in-previous-FY.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FYwhen-POL-created-in-previous-FY.cy.js
@@ -69,6 +69,7 @@ describe('Invoices', () => {
     cy.loginAsAdmin();
     cy.visit(SettingsMenu.expenseClassesPath);
     SettingsFinance.createNewExpenseClass(firstExpenseClass);
+    cy.getAdminToken();
     FiscalYears.createViaApi(firstFiscalYear).then((firstFiscalYearResponse) => {
       firstFiscalYear.id = firstFiscalYearResponse.id;
       defaultLedger.fiscalYearOneId = firstFiscalYear.id;

--- a/cypress/e2e/invoices/approve-and-pay-invoice-in-current-FY-for-previous-FY.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-in-current-FY-for-previous-FY.cy.js
@@ -75,6 +75,7 @@ describe('Invoices', () => {
           Funds.addBudget(allocatedQuantity);
         });
         secondFiscalYear.code = firstFiscalYear.code.slice(0, -1) + '2';
+        cy.getAdminToken();
         FiscalYears.createViaApi(secondFiscalYear).then((secondFiscalYearResponse) => {
           secondFiscalYear.id = secondFiscalYearResponse.id;
         });

--- a/cypress/e2e/invoices/approve-and-pay-invoice-with-currency-different-from-default.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-with-currency-different-from-default.cy.js
@@ -37,6 +37,8 @@ describe('Invoices', () => {
         Orders.createOrderWithOrderLineViaApi(testData.order, testData.orderLine).then((order) => {
           testData.order = order;
 
+          Orders.updateOrderViaApi({ ...testData.order, workflowStatus: 'Open' });
+
           OrderLines.getOrderLineViaApi({ query: `poLineNumber=="*${order.poNumber}*"` }).then(
             (orderLines) => {
               testData.orderLine = orderLines[0];

--- a/cypress/e2e/invoices/approve-invoice-in-previous-FY-and-pay-invoice-in-current FY.cy.js
+++ b/cypress/e2e/invoices/approve-invoice-in-previous-FY-and-pay-invoice-in-current FY.cy.js
@@ -82,7 +82,7 @@ describe('Invoices', () => {
           Funds.selectFund(defaultFund.name);
           Funds.addBudget(allocatedQuantity);
         });
-
+        cy.getAdminToken();
         ServicePoints.getViaApi().then((servicePoint) => {
           servicePointId = servicePoint[0].id;
           NewLocation.createViaApi(NewLocation.getDefaultLocation(servicePointId)).then((res) => {

--- a/cypress/e2e/invoices/invoice-with-fund-different-from-related-pol-can-be-approved.cy.js
+++ b/cypress/e2e/invoices/invoice-with-fund-different-from-related-pol-can-be-approved.cy.js
@@ -66,6 +66,7 @@ describe('Invoices', () => {
           Funds.addBudget(allocatedQuantity);
         });
         cy.visit(TopMenu.fundPath);
+        cy.getAdminToken();
         Funds.createViaApi(secondFund).then((secondFundResponse) => {
           secondFund.id = secondFundResponse.fund.id;
 

--- a/cypress/e2e/invoices/save-invoice-FY-after-fund-change.cy.js
+++ b/cypress/e2e/invoices/save-invoice-FY-after-fund-change.cy.js
@@ -66,10 +66,11 @@ describe('Invoices', () => {
   let location;
 
   before(() => {
-    cy.getAdminToken();
     cy.loginAsAdmin();
+    cy.getAdminToken();
     cy.visit(SettingsMenu.expenseClassesPath);
     SettingsFinance.createNewExpenseClass(firstExpenseClass);
+
     FiscalYears.createViaApi(firstFiscalYear).then((firstFiscalYearResponse) => {
       firstFiscalYear.id = firstFiscalYearResponse.id;
       defaultLedger.fiscalYearOneId = firstFiscalYear.id;

--- a/cypress/e2e/invoices/save-invoice-fiscal-year-after-fund-distribution-change.cy.js
+++ b/cypress/e2e/invoices/save-invoice-fiscal-year-after-fund-distribution-change.cy.js
@@ -68,9 +68,8 @@ describe('Invoices', () => {
   let location;
 
   before(() => {
-    cy.getAdminToken();
     cy.loginAsAdmin();
-
+    cy.getAdminToken();
     FiscalYears.createViaApi(firstFiscalYear).then((firstFiscalYearResponse) => {
       firstFiscalYear.id = firstFiscalYearResponse.id;
       firstLedger.fiscalYearOneId = firstFiscalYear.id;
@@ -83,6 +82,7 @@ describe('Invoices', () => {
           firstFund.id = firstFundResponse.fund.id;
 
           cy.loginAsAdmin({ path: TopMenu.fundPath, waiter: Funds.waitLoading });
+          cy.getAdminToken();
           FinanceHelp.searchByName(firstFund.name);
           Funds.selectFund(firstFund.name);
           Funds.addBudget(allocatedQuantity);

--- a/cypress/e2e/invoices/save-invoise-fiscal-year-after-adding-adjustment.cy.js
+++ b/cypress/e2e/invoices/save-invoise-fiscal-year-after-adding-adjustment.cy.js
@@ -84,7 +84,7 @@ describe('ui-finance: Fiscal Year Rollover', () => {
           Funds.selectFund(defaultFund.name);
           Funds.addBudget(allocatedQuantity);
         });
-
+        cy.getAdminToken();
         ServicePoints.getViaApi().then((servicePoint) => {
           servicePointId = servicePoint[0].id;
           NewLocation.createViaApi(NewLocation.getDefaultLocation(servicePointId)).then((res) => {

--- a/cypress/e2e/invoices/update-exchange-rates-on-invoice-lines-with-multiple-funds.cy.js
+++ b/cypress/e2e/invoices/update-exchange-rates-on-invoice-lines-with-multiple-funds.cy.js
@@ -72,7 +72,7 @@ describe('Invoices', () => {
           Funds.closeFundDetails();
           Funds.resetFundFilters();
         });
-
+        cy.getAdminToken();
         Funds.createViaApi(secondFund).then((secondFundResponse) => {
           secondFund.id = secondFundResponse.fund.id;
 

--- a/cypress/e2e/invoices/user-is-not-able-to-pay-previously-approved-invoice.cy.js
+++ b/cypress/e2e/invoices/user-is-not-able-to-pay-previously-approved-invoice.cy.js
@@ -42,8 +42,8 @@ describe('Invoices', () => {
   let location;
 
   before(() => {
-    cy.getAdminToken();
     cy.loginAsAdmin();
+    cy.getAdminToken();
     cy.visit(SettingsMenu.expenseClassesPath);
     SettingsFinance.createNewExpenseClass(firstExpenseClass);
     FiscalYears.createViaApi(defaultFiscalYear).then((firstFiscalYearResponse) => {

--- a/cypress/e2e/orders/close-order.cy.js
+++ b/cypress/e2e/orders/close-order.cy.js
@@ -26,6 +26,7 @@ describe('orders: Close Order', () => {
       orderLine.physical.materialType = materialType.id;
     });
     cy.loginAsAdmin();
+    cy.getAdminToken();
   });
 
   after(() => {

--- a/cypress/e2e/orders/create-one-time-order-with-pol.cy.js
+++ b/cypress/e2e/orders/create-one-time-order-with-pol.cy.js
@@ -45,6 +45,7 @@ describe('Orders: Inventory interaction', () => {
           defaultFund.id = fundResponse.fund.id;
 
           cy.loginAsAdmin({ path: TopMenu.fundPath, waiter: Funds.waitLoading });
+          cy.getAdminToken();
           FinanceHelp.searchByName(defaultFund.name);
           Funds.selectFund(defaultFund.name);
           Funds.addBudget(allocatedQuantity);
@@ -78,6 +79,7 @@ describe('Orders: Inventory interaction', () => {
 
   after(() => {
     cy.loginAsAdmin({ path: TopMenu.ordersPath, waiter: Orders.waitLoading });
+    cy.getAdminToken();
     // Need to wait until the order is opened before deleting it
     cy.wait(2000);
     Orders.deleteOrderViaApi(firstOrder.id);

--- a/cypress/e2e/orders/create-order-withPol-different-formats.cy.js
+++ b/cypress/e2e/orders/create-order-withPol-different-formats.cy.js
@@ -61,6 +61,7 @@ describe('ui-orders: Orders and Order lines', () => {
 
   afterEach(() => {
     cy.loginAsAdmin({ path: TopMenu.fundPath, waiter: Funds.waitLoading });
+    cy.getAdminToken();
     Orders.deleteOrderViaApi(order.id);
     Organizations.deleteOrganizationViaApi(organization.id);
     FinanceHelp.searchByName(defaultFund.name);

--- a/cypress/e2e/orders/po-search.cy.js
+++ b/cypress/e2e/orders/po-search.cy.js
@@ -28,6 +28,7 @@ describe('orders: Test PO search', () => {
       orderLine.physical.materialType = materialType.id;
     });
     cy.loginAsAdmin();
+    cy.getAdminToken();
   });
 
   afterEach(() => {
@@ -52,6 +53,7 @@ describe('orders: Test PO search', () => {
           ),
           orderNumber,
         );
+        cy.wait(5000);
         // open order to check 'date opened' search
         Orders.searchByParameter('PO number', orderNumber);
         Orders.selectFromResultsList(orderNumber);

--- a/cypress/e2e/orders/pol-search.cy.js
+++ b/cypress/e2e/orders/pol-search.cy.js
@@ -86,6 +86,7 @@ describe('orders: Test Po line search', () => {
       orderLine.physical.materialType = materialType.id;
     });
     cy.loginAsAdmin();
+    cy.getAdminToken();
     cy.createOrderApi(order).then(() => {
       cy.getAcquisitionMethodsApi({ query: 'value="Other"' }).then((params) => {
         orderLine.acquisitionMethod = params.body.acquisitionMethods[0].id;

--- a/cypress/support/fragments/orders/orderLines.js
+++ b/cypress/support/fragments/orders/orderLines.js
@@ -2311,4 +2311,49 @@ export default {
     cy.do(Button('Title look-up').click());
     SelectInstanceModal.waitLoading();
   },
+
+  POLWithDifferntCurrency(
+    fund,
+    unitPrice,
+    quantity,
+    value,
+    institutionId,
+    currency,
+    currencyLogo,
+    exchangeRate,
+  ) {
+    cy.do([
+      orderFormatSelect.choose(ORDER_FORMAT_NAMES.PHYSICAL_RESOURCE),
+      acquisitionMethodButton.click(),
+    ]);
+    cy.wait(2000);
+    cy.do([
+      SelectionOption(ACQUISITION_METHOD_NAMES.DEPOSITORY).click(),
+      receivingWorkflowSelect.choose(
+        RECEIVING_WORKFLOW_NAMES.SYNCHRONIZED_ORDER_AND_RECEIPT_QUANTITY,
+      ),
+      physicalUnitPriceTextField.fillIn(unitPrice),
+      quantityPhysicalTextField.fillIn(quantity),
+      materialTypeSelect.choose(MATERIAL_TYPE_NAMES.BOOK),
+      currencyButton.click(),
+      SelectionOption(currency).click(),
+      Checkbox({ id: 'use-set-exhange-rate' }).click(),
+      TextField({ name: 'cost.exchangeRate' }).fillIn(exchangeRate),
+      addFundDistributionButton.click(),
+      fundDistributionSelect.click(),
+      SelectionOption(`${fund.name} (${fund.code})`).click(),
+      Section({ id: 'fundDistributionAccordion' }).find(Button(currencyLogo)).click(),
+      fundDistributionField.fillIn(value),
+      addLocationButton.click(),
+      createNewLocationButton.click(),
+    ]);
+    cy.do([
+      TextField({ id: 'input-record-search' }).fillIn(institutionId),
+      Button('Search').click(),
+      Modal('Select locations').find(MultiColumnListCell(institutionId)).click(),
+    ]);
+    cy.do([quantityPhysicalLocationField.fillIn(quantity), saveAndCloseButton.click()]);
+    cy.wait(4000);
+    submitOrderLine();
+  },
 };


### PR DESCRIPTION
Fix Thunderjet tests for eureka:

- Add cy.getAdminToken() to tests,

- Find the method OrderLines.POLWithDifferntCurrency() and restore it, because during test C378881 run get the error: 
"TypeError: _orderLines.default.POLWithDifferntCurrency is not a function"

- Add the method Orders.updateOrderViaApi to the precondition to the test C380406 in order to make order status 'Open'. Because in the step where Invoice need to be approved we see a message "Invoice can not be approved. One or more of the related orders has a workflow status of "Pending". If desired, please open the related orders before approving this invoice."