### PR TITLE
US1261930: 3 tests added for FSE sanity AQA suite

### DIFF
--- a/cypress/e2e/fse/api/agreements.cy.js
+++ b/cypress/e2e/fse/api/agreements.cy.js
@@ -1,0 +1,14 @@
+describe('fse-agreements', () => {
+  beforeEach(() => {
+    // hide sensitive data from the allure report
+    cy.allure().logCommandSteps(false);
+    cy.getUserToken(Cypress.env('diku_login'), Cypress.env('diku_password'));
+    cy.allure().logCommandSteps();
+  });
+
+  it('TC195097 - Get agreement with active status', { tags: ['sanity', 'fse', 'api'] }, () => {
+    cy.getAgreementsByStatus('active').then((response) => {
+      cy.expect(response.status).to.eq(200);
+    });
+  });
+});

--- a/cypress/e2e/fse/api/eholdings.cy.js
+++ b/cypress/e2e/fse/api/eholdings.cy.js
@@ -1,0 +1,14 @@
+describe('fse-eholdings', () => {
+  beforeEach(() => {
+    // hide sensitive data from the report
+    cy.allure().logCommandSteps(false);
+    cy.getUserToken(Cypress.env('diku_login'), Cypress.env('diku_password'));
+    cy.allure().logCommandSteps();
+  });
+
+  it('TC195060 - Get eholdings titles', { tags: ['sanity', 'fse', 'api'] }, () => {
+    cy.getEHoldingsTitlesViaAPI('time').then((response) => {
+      cy.expect(response.status).to.eq(200);
+    });
+  });
+});

--- a/cypress/e2e/fse/api/finance.cy.js
+++ b/cypress/e2e/fse/api/finance.cy.js
@@ -1,0 +1,14 @@
+describe('fse-finance', () => {
+  beforeEach(() => {
+    // hide sensitive data from the report
+    cy.allure().logCommandSteps(false);
+    cy.getUserToken(Cypress.env('diku_login'), Cypress.env('diku_password'));
+    cy.allure().logCommandSteps();
+  });
+
+  it('TC195067 - Get fiscal year', { tags: ['sanity', 'fse', 'api', 'finance'] }, () => {
+    cy.getFiscalYearsApi({ limit: 1 }).then((response) => {
+      cy.expect(response.status).to.eq(200);
+    });
+  });
+});

--- a/cypress/support/api/agreements.js
+++ b/cypress/support/api/agreements.js
@@ -1,0 +1,7 @@
+Cypress.Commands.add('getAgreementsByStatus', (status) => {
+  cy.okapiRequest({
+    method: 'GET',
+    path: `erm/sas?filters=agreementStatus.value==${status}&sort=name&offset=1&limit=1`,
+    isDefaultSearchParamsRequired: false,
+  });
+});

--- a/cypress/support/api/eholdings.js
+++ b/cypress/support/api/eholdings.js
@@ -7,3 +7,11 @@ Cypress.Commands.add('getEHoldingsCustomLabelsViaAPI', () => {
     return body.data;
   });
 });
+
+Cypress.Commands.add('getEHoldingsTitlesViaAPI', (titleName) => {
+  cy.okapiRequest({
+    method: 'GET',
+    path: `eholdings/titles?page=1&filter[name]=${titleName}&count=1`,
+    isDefaultSearchParamsRequired: false,
+  });
+});

--- a/cypress/support/api/index.js
+++ b/cypress/support/api/index.js
@@ -1,4 +1,5 @@
 import './acq-units';
+import './agreements';
 import './auth';
 import './circulation';
 import './finance';


### PR DESCRIPTION
[US1261930](https://rally1.rallydev.com/#/21934224700d/myrally?detail=%2Fuserstory%2F780099813575), [US1261920](https://rally1.rallydev.com/#/605272773808d/teamboard?detail=%2Fuserstory%2F780089899749&view=aa30dbe3-2c38-45ee-9267-15de1c227ecb):
3 tests added for FSE AQA suite - re-creation of 3 existing synthetic canaries checks:


- agreements (get by status)
- finance (get fiscal year)
- eholdings (get by title)

See related rally ticket for details and test cases.

For existing synthetic canaries, [check this repo.](https://github.com/EBSCOIS/fse.hosting.aws-synthetics/tree/master)