### PR TITLE
FAT-14422 Support automated tests in daily run

### DIFF
--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-record-with-folio-authority-file.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-record-with-folio-authority-file.cy.js
@@ -25,9 +25,9 @@ describe('MARC', () => {
       const users = {};
 
       const newFields = [
-        { rowIndex: 4, tag: '010', content: '$a n4332123 $z n1234432333' },
+        { previousFieldTag: '008', tag: '010', content: '$a n4332123 $z n1234432333' },
         {
-          rowIndex: 5,
+          previousFieldTag: '010',
           tag: '100',
           content: '$a Create a new MARC authority record with FOLIO authority file test',
         },
@@ -57,7 +57,7 @@ describe('MARC', () => {
       after('Delete users, data', () => {
         cy.getAdminToken();
         Users.deleteViaApi(users.userProperties.userId);
-        MarcAuthority.deleteViaAPI(testData.authorityId);
+        MarcAuthority.deleteViaAPI(testData.authorityId, true);
         ManageAuthorityFiles.unsetAllDefaultFOLIOFilesAsActiveViaAPI();
       });
 
@@ -74,7 +74,11 @@ describe('MARC', () => {
           QuickMarcEditor.clickSaveAndCloseInModal();
           QuickMarcEditor.checkContentByTag(testData.tag001, '');
           newFields.forEach((newField) => {
-            MarcAuthority.addNewField(newField.rowIndex, newField.tag, newField.content);
+            MarcAuthority.addNewFieldAfterExistingByTag(
+              newField.previousFieldTag,
+              newField.tag,
+              newField.content,
+            );
           });
           QuickMarcEditor.checkContentByTag(testData.tag001, testData.tag001Value);
           QuickMarcEditor.checkContentByTag(testData.tag010, newFields[0].content);

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-record-with-local-auth-file-with-default-prefix.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-record-with-local-auth-file-with-default-prefix.cy.js
@@ -13,7 +13,7 @@ describe('MARC', () => {
       const tag001 = '001';
       const headerText = 'Create a new MARC authority record';
       const newField = {
-        rowIndex: 3,
+        previousFieldTag: '008',
         tag: '111',
         content:
           '$a C423559 Create a new MARC authority record with Local authority file which includes default prefix in it',
@@ -90,7 +90,11 @@ describe('MARC', () => {
 
           // 5 Add 1 new field by clicking on "+" icon and fill it as specified:
           // 111 \\ "$a Create a new MARC authority record with Local authority file which includes default prefix in it"
-          MarcAuthority.addNewField(newField.rowIndex, newField.tag, newField.content);
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField.previousFieldTag,
+            newField.tag,
+            newField.content,
+          );
           QuickMarcEditor.checkContentByTag(newField.tag, newField.content);
 
           // 6 Click on the "Save & close" button

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-record-with-local-authority-file.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-record-with-local-authority-file.cy.js
@@ -15,7 +15,7 @@ describe('MARC', () => {
       const headerText = 'Create a new MARC authority record';
       let createdAuthorityId;
       const newField = {
-        rowIndex: 4,
+        previousFieldTag: '008',
         tag: '100',
         content: '$a C423528 Create a new MARC authority record with Local authority file test',
       };
@@ -62,7 +62,7 @@ describe('MARC', () => {
       after('Delete users, data', () => {
         cy.getAdminToken();
         Users.deleteViaApi(users.userProperties.userId);
-        MarcAuthority.deleteViaAPI(createdAuthorityId);
+        MarcAuthority.deleteViaAPI(createdAuthorityId, true);
         ManageAuthorityFiles.unsetAllDefaultFOLIOFilesAsActiveViaAPI();
         cy.deleteAuthoritySourceFileViaAPI(localAuthFile.id, true);
       });
@@ -92,7 +92,11 @@ describe('MARC', () => {
 
           // 5 Add 1 new field by clicking on "+" icon and fill it as specified:
           // 100 \\ "$a Create a new MARC authority record with Local authority file test"
-          MarcAuthority.addNewField(newField.rowIndex, newField.tag, newField.content);
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField.previousFieldTag,
+            newField.tag,
+            newField.content,
+          );
           QuickMarcEditor.checkContentByTag(newField.tag, newField.content);
 
           // 6 Click on the "Save & close" button

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-without-folio-authority-file.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-new-marcAuth-without-folio-authority-file.cy.js
@@ -3,6 +3,7 @@ import QuickMarcEditor from '../../../../support/fragments/quickMarcEditor';
 import TopMenu from '../../../../support/fragments/topMenu';
 import Users from '../../../../support/fragments/users/users';
 import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
 
 describe('MARC', () => {
   describe('MARC Authority', () => {
@@ -10,11 +11,16 @@ describe('MARC', () => {
       const user = {};
       const headerText = 'Create a new MARC authority record';
       const errorNotification = 'Record cannot be saved. An authority file is required';
-      const newFields = {
-        tag100: '100',
-        field100Value: '$a Save without selected Authority file test',
-        tag010: '010',
-        field010Value: '$a n000232',
+
+      const newField010 = {
+        previousFieldTag: '008',
+        tag: '010',
+        content: '$a n000232',
+      };
+      const newField100 = {
+        previousFieldTag: '010',
+        tag: '100',
+        content: '$a Save without selected Authority file test',
       };
 
       before('Create users, data', () => {
@@ -51,12 +57,18 @@ describe('MARC', () => {
           // 2 Add 2 new fields by clicking on "+" icon and fill it as specified:
           // 010 \\ "$a <<enter a value in format <Prefix><Value> using any valid authority file>>", ex.: "n000232"
           // 100 \\ "$a Save without selected Authority file test"
-          QuickMarcEditor.addNewField(newFields.tag010, newFields.field010Value, 4);
-          QuickMarcEditor.addNewField(newFields.tag100, newFields.field100Value, 5);
-          QuickMarcEditor.verifyTagValue(5, newFields.tag010);
-          QuickMarcEditor.verifyTagValue(6, newFields.tag100);
-          QuickMarcEditor.checkContent(newFields.field010Value, 5);
-          QuickMarcEditor.checkContent(newFields.field100Value, 6);
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField010.previousFieldTag,
+            newField010.tag,
+            newField010.content,
+          );
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField100.previousFieldTag,
+            newField100.tag,
+            newField100.content,
+          );
+          QuickMarcEditor.checkContentByTag(newField010.tag, newField010.content);
+          QuickMarcEditor.checkContentByTag(newField100.tag, newField100.content);
 
           // 3 Click on the "Save & close" button
           QuickMarcEditor.pressSaveAndClose();

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-record-with-different-prefix-in-010-field.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-record-with-different-prefix-in-010-field.cy.js
@@ -14,12 +14,12 @@ describe('MARC', () => {
     describe('Create MARC Authority', () => {
       const headerText = 'Create a new MARC authority record';
       const newField010 = {
-        rowIndex: 4,
+        previousFieldTag: '008',
         tag: '010',
         content: '$a sj43321',
       };
       const newField100 = {
-        rowIndex: 5,
+        previousFieldTag: '010',
         tag: '100',
         content: '$a C423540 Create a new MARC authority record with not matched prefix on 010',
       };
@@ -82,8 +82,16 @@ describe('MARC', () => {
           // 010 \\ "$a <prefix value of default authority file which does NOT match the selected option><identifier value>"
           // ex.: "$a sj43321"
           // 100 \\ "$a Create a new MARC authority record with not matched prefix on 010"
-          MarcAuthority.addNewField(newField010.rowIndex, newField010.tag, newField010.content);
-          MarcAuthority.addNewField(newField100.rowIndex, newField100.tag, newField100.content);
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField010.previousFieldTag,
+            newField010.tag,
+            newField010.content,
+          );
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField100.previousFieldTag,
+            newField100.tag,
+            newField100.content,
+          );
           QuickMarcEditor.checkContentByTag(newField010.tag, newField010.content);
           QuickMarcEditor.checkContentByTag(newField100.tag, newField100.content);
 

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/created-marcAuth-could-be-found-using-search-and-browse.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/created-marcAuth-could-be-found-using-search-and-browse.cy.js
@@ -27,10 +27,14 @@ describe('MARC', () => {
       const users = {};
 
       const newFields = [
-        { rowIndex: 4, tag: '010', content: '$a n00776432' },
-        { rowIndex: 5, tag: '100', content: '$a John Doe $c Sir, $d 1909-1965 $l eng' },
-        { rowIndex: 6, tag: '400', content: '$a Huan Doe $c Senior, $d 1909-1965 $l eng' },
-        { rowIndex: 7, tag: '500', content: '$a La familia' },
+        { previousFieldTag: '008', tag: '010', content: '$a n00776432' },
+        { previousFieldTag: '010', tag: '100', content: '$a John Doe $c Sir, $d 1909-1965 $l eng' },
+        {
+          previousFieldTag: '100',
+          tag: '400',
+          content: '$a Huan Doe $c Senior, $d 1909-1965 $l eng',
+        },
+        { previousFieldTag: '400', tag: '500', content: '$a La familia' },
       ];
 
       before('Create users, data', () => {
@@ -58,7 +62,7 @@ describe('MARC', () => {
       after('Delete users, data', () => {
         cy.getAdminToken();
         Users.deleteViaApi(users.userProperties.userId);
-        MarcAuthority.deleteViaAPI(testData.authorityId);
+        MarcAuthority.deleteViaAPI(testData.authorityId, true);
         ManageAuthorityFiles.unsetAllDefaultFOLIOFilesAsActiveViaAPI();
       });
 
@@ -74,7 +78,11 @@ describe('MARC', () => {
           QuickMarcEditor.verifyAuthorityFileSelected(testData.sourceName);
           QuickMarcEditor.clickSaveAndCloseInModal();
           newFields.forEach((newField) => {
-            MarcAuthority.addNewField(newField.rowIndex, newField.tag, newField.content);
+            MarcAuthority.addNewFieldAfterExistingByTag(
+              newField.previousFieldTag,
+              newField.tag,
+              newField.content,
+            );
           });
           QuickMarcEditor.pressSaveAndClose();
           MarcAuthority.verifyAfterSaveAndClose();

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/verify-005-and-999-fields-system-generated.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/verify-005-and-999-fields-system-generated.cy.js
@@ -24,12 +24,12 @@ describe('MARC', () => {
       };
       const tag999 = '999';
       const newField010 = {
-        rowIndex: 4,
+        previousFieldTag: '008',
         tag: '010',
         content: `$a ${localAuthFile.prefix}${randomFourDigitNumber()}`,
       };
       const newField100 = {
-        rowIndex: 5,
+        previousFieldTag: '010',
         tag: '100',
         content: '$a 005 and 999 auto-generated test',
       };
@@ -93,8 +93,16 @@ describe('MARC', () => {
           // 3 Add 2 new fields by clicking on "+" icon and fill them as specified:
           // 010 \\ "$a <<enter a value in format <Prefix><Value> in accordance to selected authority file>>", ex.: "n000232"
           // 100 \\ "$a 005 and 999 auto-generated test"
-          MarcAuthority.addNewField(newField010.rowIndex, newField010.tag, newField010.content);
-          MarcAuthority.addNewField(newField100.rowIndex, newField100.tag, newField100.content);
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField010.previousFieldTag,
+            newField010.tag,
+            newField010.content,
+          );
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            newField100.previousFieldTag,
+            newField100.tag,
+            newField100.content,
+          );
           QuickMarcEditor.checkContentByTag(newField010.tag, newField010.content);
           QuickMarcEditor.checkContentByTag(newField100.tag, newField100.content);
 

--- a/cypress/e2e/marc/marc-bibliographic/create-new-marc-bib/manual-linking/link-marcBib-with-created-on-ui-marcAuth.cy.js
+++ b/cypress/e2e/marc/marc-bibliographic/create-new-marc-bib/manual-linking/link-marcBib-with-created-on-ui-marcAuth.cy.js
@@ -30,9 +30,9 @@ describe('MARC', () => {
         };
 
         const newFields = [
-          { rowIndex: 4, tag: '010', content: '$a n00776439' },
+          { previousFieldTag: '008', tag: '010', content: '$a n00776439' },
           {
-            rowIndex: 5,
+            previousFieldTag: '010',
             tag: '100',
             content: '$a John Doe $c Sir, $d 1909-1965 $l eng',
           },
@@ -90,7 +90,11 @@ describe('MARC', () => {
             QuickMarcEditor.verifyAuthorityFileSelected(testData.sourceName);
             QuickMarcEditor.clickSaveAndCloseInModal();
             newFields.forEach((newField) => {
-              MarcAuthority.addNewField(newField.rowIndex, newField.tag, newField.content);
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                newField.previousFieldTag,
+                newField.tag,
+                newField.content,
+              );
             });
             QuickMarcEditor.checkContentByTag(newFields[0].tag, newFields[0].content);
             QuickMarcEditor.checkContentByTag(newFields[1].tag, newFields[1].content);

--- a/cypress/support/fragments/marcAuthority/marcAuthority.js
+++ b/cypress/support/fragments/marcAuthority/marcAuthority.js
@@ -148,6 +148,36 @@ export default {
     ]);
   },
 
+  addNewFieldAfterExistingByTag: (
+    previousFieldTag,
+    newFieldTag,
+    content,
+    indicator0 = '\\',
+    indicator1 = '\\',
+  ) => {
+    cy.do(
+      QuickMarcEditorRow({ tagValue: previousFieldTag }).perform((element) => {
+        const rowIndex = Number(element.getAttribute('data-row').match(/\d+/)[0]);
+
+        cy.do([
+          QuickMarcEditorRow({ index: rowIndex }).find(addFieldButton).click(),
+          QuickMarcEditorRow({ index: rowIndex + 1 })
+            .find(TextField({ name: `records[${rowIndex + 1}].tag` }))
+            .fillIn(newFieldTag),
+          QuickMarcEditorRow({ index: rowIndex + 1 })
+            .find(TextField({ name: `records[${rowIndex + 1}].indicators[0]` }))
+            .fillIn(indicator0),
+          QuickMarcEditorRow({ index: rowIndex + 1 })
+            .find(TextField({ name: `records[${rowIndex + 1}].indicators[1]` }))
+            .fillIn(indicator1),
+          QuickMarcEditorRow({ index: rowIndex + 1 })
+            .find(TextArea({ name: `records[${rowIndex + 1}].content` }))
+            .fillIn(content),
+        ]);
+      }),
+    );
+  },
+
   checkLinkingAuthority650: () => {
     cy.expect(buttonLink.exists());
     cy.expect(Callout('Field 650 has been linked to a MARC authority record.').exists());


### PR DESCRIPTION
Implement a new method addNewFieldAfterExistingByTag(). This method adds a new field to the MARC authority record without relying on a hardcoded row index. Replace with it the existing addNewField() method.