### PR TITLE
FAT-14783 Point multiselect's `aria-labelledby` filter to role=combobox instead…

### DIFF
--- a/interactors/multi-select.js
+++ b/interactors/multi-select.js
@@ -88,7 +88,7 @@ export default createInteractor('multi select')
     focused: (el) => Boolean(el.querySelector(':focus')),
     focusedValue: (el) => el.querySelector('ul').querySelector('button:focus').parentNode.textContent,
     error: (el) => el.querySelector('[class^=feedbackError]').textContent,
-    ariaLabelledby: (el) => el.querySelector('[role=searchbox]').getAttribute('aria-labelledby'),
+    ariaLabelledby: (el) => el.querySelector('[role=combobox]').getAttribute('aria-labelledby'),
     span: (el) => el.querySelector('span').textContent,
   })
   .actions({


### PR DESCRIPTION
… of role=searchbox

Along with the changes on https://github.com/folio-org/stripes-components/pull/2312 this should resolve a large number of the automated test failures.