### PR TITLE
skipping validation sync

### DIFF
--- a/cypress/e2e/aaa.cy.js
+++ b/cypress/e2e/aaa.cy.js
@@ -1,4 +1,4 @@
-describe('Specifications sync', () => {
+describe.skip('Specifications sync', () => {
   it(
     'Sync marc bibliographic and marc authority records fields (smoke tests)',
     { tags: ['smoke', 'spitfire'] },


### PR DESCRIPTION
Added `skip` to the test suite for MARC specification sync.
Such synchronization is now done automatically when the env is built (https://folio-org.atlassian.net/browse/MRSPECS-53).
If this change will not cause any issues, corresponding spec file could be later removed completely.