### PR TITLE
FAT-16718 Support eureka tests

### DIFF
--- a/cypress/e2e/settings/remote-storage/remote-storage.cy.js
+++ b/cypress/e2e/settings/remote-storage/remote-storage.cy.js
@@ -47,6 +47,7 @@ describe('remote-storage-configuration', () => {
         false,
       );
       Configurations.closeEditConfiguration();
+      Configurations.clickCloseWithoutSavingButtonInAreYouSureForm();
       Configurations.deleteRemoteStorage(newName);
     });
   });
@@ -72,6 +73,7 @@ describe('remote-storage-configuration', () => {
       Configurations.editConfiguration(name, { timingInput: timingToEdit });
       Configurations.closeWithoutSaving();
       Configurations.editConfiguration(name, { urlInput: urlToEdit, timingInput: '1' });
+      Configurations.closeWithSaving();
 
       // delete created configuration
       Configurations.deleteRemoteStorage(name);

--- a/cypress/support/api/users.js
+++ b/cypress/support/api/users.js
@@ -169,6 +169,7 @@ Cypress.Commands.add(
                   path: 'capabilities',
                   searchParams: {
                     query: `(permission=="${permissionNames.join('")or(permission=="')}")`,
+                    limit: 100,
                   },
                   isDefaultSearchParamsRequired: false,
                 }).then((responseCapabs) => {
@@ -177,6 +178,7 @@ Cypress.Commands.add(
                     path: 'capability-sets',
                     searchParams: {
                       query: `(permission=="${permissionNames.join('")or(permission=="')}")`,
+                      limit: 100,
                     },
                     isDefaultSearchParamsRequired: false,
                   }).then((responseSets) => {

--- a/cypress/support/fragments/settings/remote-storage/configurations.js
+++ b/cypress/support/fragments/settings/remote-storage/configurations.js
@@ -263,6 +263,11 @@ export default {
     ]);
   },
 
+  clickCloseWithoutSavingButtonInAreYouSureForm() {
+    cy.do(Modal('Are you sure?').find(Button('Close without saving')).click());
+    cy.wait(1000);
+  },
+
   closeWithSaving() {
     return cy.do(Modal().find(Button('Save')).click());
   },


### PR DESCRIPTION
Add the property "limit: 100" to the cy.createTempUser() method to get capabilities and capability-sets, because by default those requests return only 10 records.

Add some recent changes for the tests.

