### PR TITLE
UITEST-120 migrate imports from "bigtest" to "@interactors/html"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update `<MultiSelection>` interactor. Refs STCOM-1304.
 - Hide call number type options for Local, Other scheme, and SuDoc. Refs FAT-16052.
 - Change the labels of the Classification and Call number sections in Inventory browse options. Refs FAT-16040.
+- Migrate imports from `bigtest` to `@interactors/html`. Refs UITEST-120.
 
 ## [4.7.0](https://github.com/folio-org/stripes-testing/tree/v4.7.0) (2024-03-12)
 

--- a/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
+++ b/cypress/support/fragments/bulk-edit/bulk-edit-actions.js
@@ -1,5 +1,4 @@
-import { HTML, including } from '@interactors/html';
-import { not } from 'bigtest';
+import { HTML, including, not } from '@interactors/html';
 import FileManager from '../../utils/fileManager';
 import {
   Accordion,

--- a/cypress/support/fragments/check-in-actions/checkInPane.js
+++ b/cypress/support/fragments/check-in-actions/checkInPane.js
@@ -1,5 +1,4 @@
-import { matching } from 'bigtest';
-import { HTML, including } from '@interactors/html';
+import { matching, HTML, including } from '@interactors/html';
 import { MultiColumnListCell, MultiColumnListRow } from '../../../../interactors';
 import DateTools from '../../utils/dateTools';
 

--- a/cypress/support/fragments/circulation-log/searchPane.js
+++ b/cypress/support/fragments/circulation-log/searchPane.js
@@ -1,4 +1,4 @@
-import { matching } from 'bigtest';
+import { matching } from '@interactors/html';
 import {
   Accordion,
   Button,

--- a/cypress/support/fragments/circulation-log/searchResults.js
+++ b/cypress/support/fragments/circulation-log/searchResults.js
@@ -1,4 +1,4 @@
-import { matching } from 'bigtest';
+import { matching } from '@interactors/html';
 import {
   MultiColumnList,
   MultiColumnListCell,

--- a/cypress/support/fragments/circulation/editStaffClips.js
+++ b/cypress/support/fragments/circulation/editStaffClips.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Button,
   Checkbox,

--- a/cypress/support/fragments/consortium-manager/modal/confirm-create.js
+++ b/cypress/support/fragments/consortium-manager/modal/confirm-create.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import { Button, Modal } from '../../../../../interactors';
 
 const confirmShareToAllModal = Modal({ id: 'create-controlled-vocab-entry-confirmation' });

--- a/cypress/support/fragments/consortium-manager/modal/confirm-share.js
+++ b/cypress/support/fragments/consortium-manager/modal/confirm-share.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import { Button, Modal } from '../../../../../interactors';
 
 const confirmShareToAllModal = Modal({ id: 'share-controlled-vocab-entry-confirmation' });

--- a/cypress/support/fragments/consortium-manager/modal/delete-cancel-reason.js
+++ b/cypress/support/fragments/consortium-manager/modal/delete-cancel-reason.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import { Button, Modal } from '../../../../../interactors';
 
 const deleteCancelReasonModal = Modal({ id: 'delete-controlled-vocab-entry-confirmation' });

--- a/cypress/support/fragments/data-export/dataExportResults.js
+++ b/cypress/support/fragments/data-export/dataExportResults.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   ListRow,
   MultiColumnListCell,

--- a/cypress/support/fragments/data-export/exportJobProfile/exportJobProfiles.js
+++ b/cypress/support/fragments/data-export/exportJobProfile/exportJobProfiles.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Pane,
   NavListItem,

--- a/cypress/support/fragments/data-export/exportMappingProfile/exportFieldMappingProfiles.js
+++ b/cypress/support/fragments/data-export/exportMappingProfile/exportFieldMappingProfiles.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Button,
   Pane,

--- a/cypress/support/fragments/data-export/exportMappingProfile/singleFieldMappingProfilePane.js
+++ b/cypress/support/fragments/data-export/exportMappingProfile/singleFieldMappingProfilePane.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Accordion,
   PaneHeader,

--- a/cypress/support/fragments/data_import/matchOnVRN.js
+++ b/cypress/support/fragments/data_import/matchOnVRN.js
@@ -1,5 +1,5 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-import { not } from 'bigtest';
+import { not } from '@interactors/html';
 import {
   Accordion,
   Button,

--- a/cypress/support/fragments/inventory/holdings/inventoryHoldings.js
+++ b/cypress/support/fragments/inventory/holdings/inventoryHoldings.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import { Accordion } from '../../../../../interactors';
 import InventoryItems from '../item/inventoryItems';
 

--- a/cypress/support/fragments/inventory/search/browseSubjects.js
+++ b/cypress/support/fragments/inventory/search/browseSubjects.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-dupe-keys */
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   matching,
   Button,

--- a/cypress/support/fragments/loans/loansPage.js
+++ b/cypress/support/fragments/loans/loansPage.js
@@ -1,4 +1,4 @@
-import { matching } from 'bigtest';
+import { matching } from '@interactors/html';
 import {
   Button,
   Pane,

--- a/cypress/support/fragments/oai-pmh/general.js
+++ b/cypress/support/fragments/oai-pmh/general.js
@@ -1,4 +1,4 @@
-import { matching } from 'bigtest';
+import { matching } from '@interactors/html';
 import { Checkbox, Pane, Select, TextArea, TextField, Button } from '../../../../interactors';
 
 const generalPane = Pane('General');

--- a/cypress/support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfileView.js
+++ b/cypress/support/fragments/settings/dataImport/fieldMappingProfile/fieldMappingProfileView.js
@@ -1,5 +1,4 @@
-import { HTML, including } from '@interactors/html';
-import { matching } from 'bigtest';
+import { HTML, including, matching } from '@interactors/html';
 import {
   Accordion,
   Button,

--- a/cypress/support/fragments/settings/dataImport/matchProfiles/newMatchProfile.js
+++ b/cypress/support/fragments/settings/dataImport/matchProfiles/newMatchProfile.js
@@ -1,5 +1,4 @@
-import { HTML, including } from '@interactors/html';
-import { not } from 'bigtest';
+import { HTML, including, not } from '@interactors/html';
 import {
   Accordion,
   Button,

--- a/cypress/support/fragments/settings/inventory/instance-holdings-item/urlRelationship.js
+++ b/cypress/support/fragments/settings/inventory/instance-holdings-item/urlRelationship.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Button,
   MultiColumnListRow,

--- a/cypress/support/fragments/settings/users/customFields.js
+++ b/cypress/support/fragments/settings/users/customFields.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Accordion,
   Button,

--- a/cypress/support/fragments/settings/users/paymentMethods.js
+++ b/cypress/support/fragments/settings/users/paymentMethods.js
@@ -1,4 +1,4 @@
-import { not } from 'bigtest';
+import { not } from '@interactors/html';
 import uuid from 'uuid';
 
 import {

--- a/cypress/support/fragments/settings/users/waiveReasons.js
+++ b/cypress/support/fragments/settings/users/waiveReasons.js
@@ -1,4 +1,4 @@
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 import {
   Button,
   MultiColumnListCell,

--- a/cypress/support/fragments/users/feeFines.js
+++ b/cypress/support/fragments/users/feeFines.js
@@ -1,4 +1,4 @@
-import { matching } from 'bigtest';
+import { matching } from '@interactors/html';
 import { MultiColumnListRow, MultiColumnListCell, including } from '../../../../interactors';
 
 export default {

--- a/cypress/support/fragments/users/loans/userLoans.js
+++ b/cypress/support/fragments/users/loans/userLoans.js
@@ -1,4 +1,4 @@
-import { matching } from 'bigtest';
+import { matching } from '@interactors/html';
 import moment from 'moment';
 import {
   Button,

--- a/cypress/support/fragments/users/userCharge.js
+++ b/cypress/support/fragments/users/userCharge.js
@@ -1,4 +1,4 @@
-import { not } from 'bigtest';
+import { not } from '@interactors/html';
 import { Button, Modal, Select, TextField } from '../../../../interactors';
 import UsersCard from './usersCard';
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "axe-core": "4.3.3",
     "axios": "^1.7.7",
     "babel-loader": "^9.2.1",
-    "bigtest": "^0.16.1",
     "cypress": "12.0.0",
     "cypress-cloud": "^1.9.6",
     "cypress-downloadfile": "^1.2.1",


### PR DESCRIPTION
Just like it says on the tin: migrate imports from `bigtest`, which contains many unmaintained dependencies (e.g. old versions of `minimist` vulnerable to CVE-2021-44906), to imports from `@interactors/html` which is maintained.

Refs [UITEST-120](https://folio-org.atlassian.net/browse/UITEST-120)