### PR TITLE
UITEST-125: Update `ui-quick-marc.quick-marc-editor.duplicate` and `ui-quick-marc.quick-marc-authority-records.linkUnlink` permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change the labels of the Classification and Call number sections in Inventory browse options. Refs FAT-16040.
 - Migrate imports from `bigtest` to `@interactors/html`. Refs UITEST-120.
 - Refactor ui-inventory permissions. Refs UITEST-121.
+- Update `ui-quick-marc.quick-marc-editor.duplicate` and `ui-quick-marc.quick-marc-authority-records.linkUnlink` permissions. Refs UITEST-121.
 
 ## [4.7.0](https://github.com/folio-org/stripes-testing/tree/v4.7.0) (2024-03-12)
 

--- a/cypress/support/dictionary/permissions.js
+++ b/cypress/support/dictionary/permissions.js
@@ -78,7 +78,7 @@ export default {
     gui: 'quickMARC: Create a new MARC bibliographic record',
   },
   uiQuickMarcQuickMarcEditorDuplicate: {
-    internal: 'ui-quick-marc.quick-marc-editor.duplicate',
+    internal: 'ui-quick-marc.quick-marc-editor.duplicate.execute',
     gui: 'quickMARC: Derive new MARC bibliographic record',
   },
   uiQuickMarcQuickMarcBibliographicEditorAll: {
@@ -98,7 +98,7 @@ export default {
     gui: 'quickMARC: View MARC bibliographic record',
   },
   uiQuickMarcQuickMarcAuthorityLinkUnlink: {
-    internal: 'ui-quick-marc.quick-marc-authority-records.linkUnlink',
+    internal: 'ui-quick-marc.quick-marc-authority-records.link-unlink.execute',
     gui: 'quickMARC: Can Link/unlink authority records to bib records',
   },
   uiQuickMarcQuickMarcAuthorityCreate: {

--- a/cypress/support/dictionary/permissions.js
+++ b/cypress/support/dictionary/permissions.js
@@ -78,7 +78,7 @@ export default {
     gui: 'quickMARC: Create a new MARC bibliographic record',
   },
   uiQuickMarcQuickMarcEditorDuplicate: {
-    internal: 'ui-quick-marc.quick-marc-editor.duplicate.execute',
+    internal: 'ui-quick-marc.quick-marc-editor.derive.execute',
     gui: 'quickMARC: Derive new MARC bibliographic record',
   },
   uiQuickMarcQuickMarcBibliographicEditorAll: {


### PR DESCRIPTION
## Description
Update `ui-quick-marc.quick-marc-editor.duplicate` and `ui-quick-marc.quick-marc-authority-records.linkUnlink` permissions to match https://github.com/folio-org/ui-quick-marc/pull/751

## Issues
https://folio-org.atlassian.net/browse/UITEST-125

