### PR TITLE
UITEST-127: Change `advanced-search` -> `fillQuery` interactor from `ariaLabel` to `dataTestID`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Rename the `ui-eholdings.titles-packages.create-delete` and `ui-eholdings.package-title.select-unselect` permissions. Refs UITEST-123.
 - Rename the `ui-notes.item.assign-unassign` permission. Refs UITEST-124.
 - Update `ui-quick-marc.quick-marc-editor.duplicate` and `ui-quick-marc.quick-marc-authority-records.linkUnlink` permissions. Refs UITEST-121.
+- Change `advanced-search` -> `fillQuery` interactor from `ariaLabel` to `dataTestID`. Refs UITEST-127.
 
 ## [4.7.0](https://github.com/folio-org/stripes-testing/tree/v4.7.0) (2024-03-12)
 

--- a/interactors/advanced-search.js
+++ b/interactors/advanced-search.js
@@ -15,7 +15,7 @@ export const AdvancedSearchRow = HTML.extend('advanced search row')
     option: (el) => el.querySelectorAll(`select#advanced-search-option-${getRowIndex(el)}`).value,
   })
   .actions({
-    fillQuery: ({ find }, value) => find(TextArea({ ariaLabel: 'Search for' })).fillIn(value),
+    fillQuery: ({ find }, value) => find(TextArea({ dataTestID: 'advanced-search-query' })).fillIn(value),
     selectBoolean: ({ find }, rowIndex, value) => find(Select({ id: `advanced-search-bool-${rowIndex}` })).choose(value),
     selectMatchOption: ({ find }, rowIndex, value) => find(Select({ id: `advanced-search-match-${rowIndex}` })).choose(value),
     selectSearchOption: ({ find }, rowIndex, value) => find(Select({ id: `advanced-search-option-${rowIndex}` })).choose(value),


### PR DESCRIPTION
## Description
Advanced search uses `ariaLabel` to find the input box. If the label is changed, it also requires changing the `stripes-testing` module each time. The solution is to rely only on `dataTestID`, which should be persistent.

## Issues
[UITEST-127](https://folio-org.atlassian.net/browse/UITEST-127)
