### PR TITLE
Spitfire double hyphen updates

### DIFF
--- a/cypress/e2e/marc/marc-authority/advanced-search/marc-authority-advanced-search-not-splitting.cy.js
+++ b/cypress/e2e/marc/marc-authority/advanced-search/marc-authority-advanced-search-not-splitting.cy.js
@@ -71,13 +71,13 @@ describe('MARC', () => {
       ];
 
       const searchResults = [
-        ['Judaismsplitauto and literature--Unitedsplitauto States--History--20th century'],
-        ['Rhetoric--Political aspects--or Unitedsplitauto States--History--20th century'],
-        ['Liberalism or not--Unitedsplitauto States--History--20th century'],
+        ['Judaismsplitauto and literature Unitedsplitauto States History 20th century'],
+        ['Rhetoric Political aspects or Unitedsplitauto States History 20th century'],
+        ['Liberalism or not Unitedsplitauto States History 20th century'],
         [
-          'Judaismsplitauto and literature--Unitedsplitauto States--History--20th century',
-          'Liberalism or not--Unitedsplitauto States--History--20th century',
-          'Rhetoric--Political aspects--or Unitedsplitauto States--History--20th century',
+          'Judaismsplitauto and literature Unitedsplitauto States History 20th century',
+          'Liberalism or not Unitedsplitauto States History 20th century',
+          'Rhetoric Political aspects or Unitedsplitauto States History 20th century',
         ],
       ];
 

--- a/cypress/e2e/marc/marc-authority/verify-subject-option-uses-all-search-operator.cy.js
+++ b/cypress/e2e/marc/marc-authority/verify-subject-option-uses-all-search-operator.cy.js
@@ -12,7 +12,7 @@ describe('MARC', () => {
     const testData = {
       searchOptions: ['Keyword', 'Subject'],
       recordType: 'Authorized',
-      marcValue: 'C584450 Discrimination in employment--Law and legislation',
+      marcValue: 'C584450 Discrimination in employment Law and legislation',
       searchQueries: [
         'Discrimination in employment Law and legislation',
         'Discrimination in employment legislation and law',

--- a/cypress/e2e/marc/marc-bibliographic/edit-marc-bib/manual-linking/linking-bibField110-to-authority110-with-record.cy.js
+++ b/cypress/e2e/marc/marc-bibliographic/edit-marc-bib/manual-linking/linking-bibField110-to-authority110-with-record.cy.js
@@ -19,7 +19,6 @@ describe('MARC', () => {
         const testData = {
           tag110: '110',
           authorityMarkedValue: 'C374194 Beatles',
-          subjectValue: 'C374194 Speaking Oratory--debating',
           linkedIconText: 'Linked to MARC authority',
           accordion: 'Contributor',
         };

--- a/cypress/e2e/marc/marc-bibliographic/edit-marc-bib/manual-linking/linking-bibField111-to-authority111-with-record.cy.js
+++ b/cypress/e2e/marc/marc-bibliographic/edit-marc-bib/manual-linking/linking-bibField111-to-authority111-with-record.cy.js
@@ -19,7 +19,6 @@ describe('MARC', () => {
         const testData = {
           tag111: '111',
           authorityMarkedValue: 'Mediterranean Conference on Medical and Biological Engineering',
-          subjectValue: 'C374197 Speaking Oratory--debating',
           linkedIconText: 'Linked to MARC authority',
           accordion: 'Contributor',
         };

--- a/cypress/e2e/marc/plug-in-marc-authority/plug-in-marc-authority-browse/plug-in-marc-authority-browse-by-corporate.cy.js
+++ b/cypress/e2e/marc/plug-in-marc-authority/plug-in-marc-authority-browse/plug-in-marc-authority-browse-by-corporate.cy.js
@@ -22,7 +22,7 @@ describe('MARC', () => {
         typeOfHeadingB: 'Conference Name',
         value: 'UXPROD-4394C380552',
         valueFullText:
-          'UXPROD-4394C380552 updated Corporate name 110 Apple & Honey Productions subb subc subd subg subn--subv--subx--suby--subz',
+          'UXPROD-4394C380552 updated Corporate name 110 Apple & Honey Productions subb subc subd subg subn subv subx suby subz',
         validSearchResults: [
           'UXPROD-4394C380552 updated Corporate name 110',
           'UXPROD-4394C380552 updated Corporate name 410',
@@ -34,10 +34,10 @@ describe('MARC', () => {
           'UXPROD-4394C380552 updated Conference Name 511',
         ],
         unvalidSearchResults: [
-          'UXPROD-4394C380552 Corporate name 110 Apple & Honey Productions subb subc subd subg subn subk--subv--subx--suby--subz',
-          'UXPROD-4394C380552 Corporate name 410 Apple and Honey Productions subb subc subd subg subn subk--subv--subx--suby--subz',
-          'UXPROD-4394C380552 Conference Name 111 Western Region Agricultural Education Research Meeting subc subd subn subq subg subk--subv--subx--suby--subz',
-          'UXPROD-4394C380552 Conference Name 411 Western Regional Agricultural Education Research Meeting subc subd subn subq subg subk--subv--subx--suby--subz',
+          'UXPROD-4394C380552 Corporate name 110 Apple & Honey Productions subb subc subd subg subn subk subv subx suby subz',
+          'UXPROD-4394C380552 Corporate name 410 Apple and Honey Productions subb subc subd subg subn subk subv subx suby subz',
+          'UXPROD-4394C380552 Conference Name 111 Western Region Agricultural Education Research Meeting subc subd subn subq subg subk subv subx suby subz',
+          'UXPROD-4394C380552 Conference Name 411 Western Regional Agricultural Education Research Meeting subc subd subn subq subg subk subv subx suby subz',
         ],
       };
 
@@ -147,7 +147,7 @@ describe('MARC', () => {
           MarcAuthorities.checkFieldAndContentExistence('110', testData.value);
           MarcAuthorities.chooseTypeOfHeading('Conference Name');
           MarcAuthorityBrowse.checkResultWithNoValue(
-            'UXPROD-4394C380552 Conference Name 411 Western Regional Agricultural Education Research Meeting subc subd subn subq subg subk--subv--subx--suby--subz',
+            'UXPROD-4394C380552 Conference Name 411 Western Regional Agricultural Education Research Meeting subc subd subn subq subg subk subv subx suby subz',
           );
         },
       );

--- a/cypress/e2e/marc/plug-in-marc-authority/plug-in-marc-authority-browse/plug-in-marc-authority-browse-by-personal-name.cy.js
+++ b/cypress/e2e/marc/plug-in-marc-authority/plug-in-marc-authority-browse/plug-in-marc-authority-browse-by-personal-name.cy.js
@@ -17,15 +17,15 @@ describe('MARC', () => {
         searchOption: 'Personal name',
         value: 'UXPROD-4394C380551',
         valueFullText:
-          'UXPROD-4394C380551 Personal name 100 Elizabeth II, Queen of Great Britain, 1926- subg subq--Musical settings--Literary style--Stage history--1950---England',
+          'UXPROD-4394C380551 Personal name 100 Elizabeth II, Queen of Great Britain, 1926- subg subq Musical settings Literary style Stage history 1950- England',
         validSearchResults: [
           'UXPROD-4394C380551 Personal name 100 Elizabeth',
           'UXPROD-4394C380551 Personal name 400 Elizabeth,',
         ],
         unvalidSearchResults: [
-          'UXPROD-4394C380551 Personal name 500 Windsor (Royal house : 1917- : Great Britain) II subg subq--subv--subx--suby--subz',
-          'UXPROD-4394C380551 Personal name 100 Elizabeth II, Queen of Great Britain, 1926- subg subq subk--Musical settings--Literary style--Stage history--1950---England',
-          'UXPROD-4394C380551 Personal name 400 Elizabeth, II Princess, Duchess of Edinburgh, 1926- subg subq subk--subv--subx--suby--subz',
+          'UXPROD-4394C380551 Personal name 500 Windsor (Royal house : 1917- : Great Britain) II subg subq subv subx suby subz',
+          'UXPROD-4394C380551 Personal name 100 Elizabeth II, Queen of Great Britain, 1926- subg subq subk Musical settings Literary style Stage history 1950- England',
+          'UXPROD-4394C380551 Personal name 400 Elizabeth, II Princess, Duchess of Edinburgh, 1926- subg subq subk subv subx suby subz',
         ],
       };
 


### PR DESCRIPTION
Double hyphens before marc authority subfield values are not expected on Snapshot/Cypress envs, while double hyphens for MARC instance subject subfields are still expected.

Reviewed/updated tests with "--" in test data strings:
C405513 - no changes
C356824 - no changes
C375259 - no changes
C466296 - no changes
C627240 - no changes
C584450 - removed hyphens
C466217 - removed hyphens
C388641 - minor fix, no hyphen changes
C374194 - removed string (not used)
C374197 - removed string (not used)
C375070 - no changes
C380552 - removed hyphens
C380551 - removed hyphens

Verified no issues caused by these updates.