### PR TITLE
Update of "Keyword..." label on "Item" tab (FAT-20062)

### DIFF
--- a/cypress/e2e/inventory/search-in-inventory/check-what-options-displayed-in-the-search-option-droprodwns.cy.js
+++ b/cypress/e2e/inventory/search-in-inventory/check-what-options-displayed-in-the-search-option-droprodwns.cy.js
@@ -7,7 +7,8 @@ import Users from '../../../support/fragments/users/users';
 
 describe('Inventory', () => {
   describe('Search in Inventory', () => {
-    const defaultSearchOption = 'Keyword (title, contributor, identifier, HRID, UUID)';
+    const defaultSearchOptionHoldings = 'Keyword (title, contributor, identifier, HRID, UUID)';
+    const defaultSearchOptionItem = 'Keyword (title, contributor, identifier, HRID, UUID, barcode)';
     let user;
 
     before('Create user, test data', () => {
@@ -40,7 +41,7 @@ describe('Inventory', () => {
         // 2 Click on the "Holdings" tab in "Instance|Holdings|Item" toggle
         InventorySearchAndFilter.switchToHoldings();
         cy.wait(1000);
-        InventorySearchAndFilter.verifyDefaultSearchOptionSelected(defaultSearchOption);
+        InventorySearchAndFilter.verifyDefaultSearchOptionSelected(defaultSearchOptionHoldings);
         InventorySearchAndFilter.checkSearchQueryText('');
         InventorySearchAndFilter.verifyResultPaneEmpty();
 
@@ -50,7 +51,7 @@ describe('Inventory', () => {
         // 4 Click on the "Item" tab in "Instance|Holdings|Item" toggle
         InventorySearchAndFilter.switchToItem();
         cy.wait(1000);
-        InventorySearchAndFilter.verifyDefaultSearchOptionSelected(defaultSearchOption);
+        InventorySearchAndFilter.verifyDefaultSearchOptionSelected(defaultSearchOptionItem);
         InventorySearchAndFilter.checkSearchQueryText('');
         InventorySearchAndFilter.verifyResultPaneEmpty();
 

--- a/cypress/e2e/inventory/search-in-select-instance-plugin/check-options-displayed-in-the-search-option-dropdown-in three-segments.cy.js
+++ b/cypress/e2e/inventory/search-in-select-instance-plugin/check-options-displayed-in-the-search-option-dropdown-in three-segments.cy.js
@@ -11,7 +11,8 @@ import TopMenu from '../../../support/fragments/topMenu';
 
 describe('Inventory', () => {
   describe('Search in "Select instance" plugin', () => {
-    const defaultSearchOption = 'Keyword (title, contributor, identifier, HRID, UUID)';
+    const defaultSearchOptionHoldings = 'Keyword (title, contributor, identifier, HRID, UUID)';
+    const defaultSearchOptionItem = 'Keyword (title, contributor, identifier, HRID, UUID, barcode)';
     const organization = {
       ...NewOrganization.defaultUiOrganizations,
       paymentMethod: 'EFT',
@@ -69,7 +70,7 @@ describe('Inventory', () => {
         // 2 Click on the "Holdings" tab in "Instance|Holdings|Item" toggle
         SelectInstanceModal.switchToHoldings();
         cy.wait(1000);
-        SelectInstanceModal.checkDefaultSearchOptionSelected(defaultSearchOption);
+        SelectInstanceModal.checkDefaultSearchOptionSelected(defaultSearchOptionHoldings);
         SelectInstanceModal.checkSearchInputFieldValue('');
         SelectInstanceModal.checkResultsListEmpty();
 
@@ -79,7 +80,7 @@ describe('Inventory', () => {
         // 4 Click on the "Item" tab in "Instance|Holdings|Item" toggle
         SelectInstanceModal.switchToItem();
         cy.wait(1000);
-        InventorySearchAndFilter.verifyDefaultSearchOptionSelected(defaultSearchOption);
+        InventorySearchAndFilter.verifyDefaultSearchOptionSelected(defaultSearchOptionItem);
         SelectInstanceModal.checkSearchInputFieldValue('');
         SelectInstanceModal.checkResultsListEmpty();
 

--- a/cypress/support/fragments/inventory/inventoryInstances.js
+++ b/cypress/support/fragments/inventory/inventoryInstances.js
@@ -112,7 +112,7 @@ const searchHoldingsOptions = [
   'Advanced search',
 ];
 export const searchItemsOptions = [
-  'Keyword (title, contributor, identifier, HRID, UUID)',
+  'Keyword (title, contributor, identifier, HRID, UUID, barcode)',
   'Barcode',
   'ISBN',
   'ISSN',

--- a/cypress/support/fragments/orders/modals/selectInstanceModal.js
+++ b/cypress/support/fragments/orders/modals/selectInstanceModal.js
@@ -55,7 +55,7 @@ const searchHoldingsOptions = [
   'Query search',
 ];
 const searchItemsOptions = [
-  'Keyword (title, contributor, identifier, HRID, UUID)',
+  'Keyword (title, contributor, identifier, HRID, UUID, barcode)',
   'Barcode',
   'ISBN',
   'ISSN',


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FAT-20062 
Label of default search option on "Item" tab is changed to: "Keyword (title, contributor, identifier, HRID, UUID, barcode)"

Allure report: 
https://jenkins.ci.folio.org/job/folioTestingTools/job/runCypressTests/8295/allure/#suites/70cae361de89575d08e2aa2ffb0cebf1/b73ab87245cc5f85/
https://jenkins.ci.folio.org/job/folioTestingTools/job/runCypressTests/8296/allure/#suites/9ff0068b62249e74aec26e539173fc84/4ce0c151240a7c4b/

Updated test cases:
https://foliotest.testrail.io//index.php?/cases/view/464058
https://foliotest.testrail.io/index.php?/cases/view/466161