### PR TITLE
FAT-20132 - update pane header label of create quickmarc pane

### DIFF
--- a/cypress/e2e/consortia/marc/marc-bibliographic/create-new-marcBib/create-local-marc-bib-in-member.cy.js
+++ b/cypress/e2e/consortia/marc/marc-bibliographic/create-new-marcBib/create-local-marc-bib-in-member.cy.js
@@ -13,6 +13,7 @@ describe('MARC', () => {
   describe('MARC Bibliographic', () => {
     describe('Create new MARC bib', () => {
       const testData = {
+        headerText: 'New local MARC bib record',
         tags: {
           tag245: '245',
         },
@@ -81,6 +82,8 @@ describe('MARC', () => {
           }, 20_000);
           ConsortiumManager.switchActiveAffiliation(tenantNames.central, tenantNames.college);
           InventoryInstance.newMarcBibRecord();
+          // Verify pane header label
+          QuickMarcEditor.checkPaneheaderContains(testData.headerText);
           QuickMarcEditor.updateExistingField(
             testData.tags.tag245,
             `$a ${testData.fieldContents.tag245Content}`,

--- a/cypress/e2e/consortia/marc/marc-bibliographic/create-new-marcBib/create-shared-marc-bib-in-central.cy.js
+++ b/cypress/e2e/consortia/marc/marc-bibliographic/create-new-marcBib/create-shared-marc-bib-in-central.cy.js
@@ -13,6 +13,7 @@ describe('MARC', () => {
   describe('MARC Bibliographic', () => {
     describe('Create new MARC bib', () => {
       const testData = {
+        headerText: 'New shared MARC bib record',
         tags: {
           tag245: '245',
         },
@@ -83,6 +84,8 @@ describe('MARC', () => {
         { tags: ['criticalPathECS', 'spitfire', 'C422123'] },
         () => {
           InventoryInstance.newMarcBibRecord();
+          // Verify pane header label
+          QuickMarcEditor.checkPaneheaderContains(testData.headerText);
           QuickMarcEditor.updateExistingField(
             testData.tags.tag245,
             `$a ${testData.fieldContents.tag245Content}`,

--- a/cypress/e2e/marc/marc-bibliographic/create-new-marc-bib/create-new-marc-bib-check-pane.cy.js
+++ b/cypress/e2e/marc/marc-bibliographic/create-new-marc-bib/create-new-marc-bib-check-pane.cy.js
@@ -9,7 +9,7 @@ describe('MARC', () => {
   describe('MARC Bibliographic', () => {
     describe('Create new MARC bib', () => {
       const testData = {
-        headerText: 'New MARC bib record',
+        headerText: /New .*MARC bib record/,
       };
 
       before('Create test data', () => {

--- a/cypress/e2e/marc/marc-bibliographic/create-new-marc-bib/create-new-marc-bib-check-pane.cy.js
+++ b/cypress/e2e/marc/marc-bibliographic/create-new-marc-bib/create-new-marc-bib-check-pane.cy.js
@@ -8,7 +8,9 @@ import Users from '../../../../support/fragments/users/users';
 describe('MARC', () => {
   describe('MARC Bibliographic', () => {
     describe('Create new MARC bib', () => {
-      const testData = {};
+      const testData = {
+        headerText: 'New MARC bib record',
+      };
 
       before('Create test data', () => {
         cy.createTempUser([
@@ -40,6 +42,8 @@ describe('MARC', () => {
           // Click on "Actions" button in second pane
           // Click on "+New MARC Bib Record" option in expanded "Actions" menu
           InventoryInstance.newMarcBibRecord();
+          // Verify pane header label
+          QuickMarcEditor.checkPaneheaderContains(testData.headerText);
           // Verify certain fields pre-populated with default values
           QuickMarcEditor.checkDefaultContent();
           // Close the pane with title "Create a new MARC bib record" by clicking on "x" icon in the upper left corner.

--- a/cypress/e2e/marc/marc-holdings/create-new-marc-holdings.cy.js
+++ b/cypress/e2e/marc/marc-holdings/create-new-marc-holdings.cy.js
@@ -188,6 +188,8 @@ describe('MARC', () => {
         InventoryInstance.checkExpectedMARCSource();
         InventoryInstance.goToMarcHoldingRecordAdding();
         QuickMarcEditor.waitLoading();
+        QuickMarcEditor.checkPaneheaderContains(testData.headerTitle);
+        QuickMarcEditor.checkPaneheaderContains(testData.headerSubtitle);
         QuickMarcEditor.verifySaveAndCloseButtonEnabled(false);
         QuickMarcEditor.updateExistingField(testData.tag852, QuickMarcEditor.getExistingLocation());
         QuickMarcEditor.verifySaveAndCloseButtonEnabled();
@@ -218,8 +220,6 @@ describe('MARC', () => {
         InventoryInstances.searchByTitle(instanceIds[0]);
         InventoryInstance.goToMarcHoldingRecordAdding();
         QuickMarcEditor.waitLoading();
-        QuickMarcEditor.checkPaneheaderContains(testData.headerTitle);
-        QuickMarcEditor.checkPaneheaderContains(testData.headerSubtitle);
         QuickMarcEditor.verifyInitialLDRFieldsValuesInMarcHoldingRecord();
         QuickMarcEditor.checkReadOnlyHoldingsTags();
         QuickMarcEditor.verifyHoldingsDefault008BoxesValues(testData.default008BoxesValues);

--- a/cypress/support/fragments/quickMarcEditor.js
+++ b/cypress/support/fragments/quickMarcEditor.js
@@ -1947,9 +1947,7 @@ export default {
   },
 
   checkRecordStatusNew() {
-    cy.expect(
-      Pane(matching(/Create a new .*MARC authority record/)).has({ subtitle: 'Status:New' }),
-    );
+    cy.expect(Pane(matching(/New .*MARC authority record/)).has({ subtitle: 'Status:New' }));
   },
 
   verifyPaneheaderWithContentAbsent(text) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FAT-20132

Label of create pane in "quickmarc" was updated.

Allure reports:
Non-ECS:
https://jenkins.ci.folio.org/job/folioTestingTools/job/runCypressTests/8300/allure/#suites/a64df16dd423bcf8901a28ccfb6cab2d/cd8f5d15bf793e1b/

ESC:
https://jenkins.ci.folio.org/job/folioTestingTools/job/runCypressTests/8306/allure/#suites