### PR TITLE
UITEST-136: Use `MessageBanner` stripes component for user patron blocks warning. Update its message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.0 IN PROGRESS
 * Export the Applist interactor.
 * Removed alerts and reporting codes. Refs MODORDERS-1269.
+* Use MessageBanner stripes component for user patron blocks warning. Update its message. Refs UITEST-136.
 
 ## [5.0.0](https://github.com/folio-org/stripes-testing/tree/v5.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-testing/compare/v4.8.0...v5.0.0)

--- a/cypress/support/fragments/users/usersCard.js
+++ b/cypress/support/fragments/users/usersCard.js
@@ -9,6 +9,7 @@ import {
   KeyValue,
   List,
   ListItem,
+  MessageBanner,
   Modal,
   MultiColumnList,
   MultiColumnListCell,
@@ -60,7 +61,7 @@ const closedRequestsLink = requestsAccordion.find(HTML({ id: 'clickable-viewclos
 const notesSection = Accordion('Notes');
 const actionsButton = rootSection.find(Button('Actions'));
 const errors = {
-  patronHasBlocksInPlace: 'Patron has block(s) in place',
+  patronHasBlocksInPlace: 'Patron has block in place',
 };
 const feesFinesAccordion = rootSection.find(Accordion({ id: 'accountsSection' }));
 const newNoteButton = notesSection.find(Button({ id: 'note-create-button' }));
@@ -547,7 +548,7 @@ export default {
   },
 
   hasSaveError(errorMessage) {
-    cy.expect(rootSection.find(TextField({ value: errorMessage })).exists());
+    cy.expect(rootSection.find(MessageBanner({ textContent: errorMessage })).exists());
   },
   startFeeFineAdding() {
     cy.do(feesFinesAccordion.find(Button('Create fee/fine')).click());


### PR DESCRIPTION
## Description
This is a fix for the https://jenkins.ci.folio.org/job/folioScheduledTesting/job/folioQualityGates/1659/allure/#suites/cd1af563c364c83f0cb7307ff326d221/211c29e7693e70a4/

Test C11020 failed due to recent changes in the patron block message banner:
https://folio-org.atlassian.net/browse/UIU-3120 
https://folio-org.atlassian.net/browse/UIU-3394 

Use `MessageBanner` stripes component for user patron blocks warning. Update its message.

## Issues
https://folio-org.atlassian.net/browse/UITEST-136