### PR TITLE
FAT-20366 Add waiters between page switching

### DIFF
--- a/cypress/e2e/orders/export/export-orders.cy.js
+++ b/cypress/e2e/orders/export/export-orders.cy.js
@@ -37,6 +37,7 @@ describe('Orders', () => {
     let orderSuffixId;
 
     before(() => {
+      cy.clearLocalStorage(); // Clear local storage to avoid issues with filters in test
       cy.getAdminToken();
       SettingsOrders.createPrefixViaApi(order.poNumberPrefix).then((prefixId) => {
         orderPrefixId = prefixId;
@@ -118,6 +119,7 @@ describe('Orders', () => {
       'C196749 Export orders based on orders search (thunderjet)',
       { tags: ['smoke', 'thunderjet', 'eurekaPhase1'] },
       () => {
+        Orders.waitLoading();
         Orders.selectOpenStatusFilter();
         Orders.waitOrdersListLoading();
         Orders.exportResultsToCsv();

--- a/cypress/e2e/orders/unopen-order-with-changed-fund-distribution.cy.js
+++ b/cypress/e2e/orders/unopen-order-with-changed-fund-distribution.cy.js
@@ -7,11 +7,16 @@ import permissions from '../../support/dictionary/permissions';
 import Budgets from '../../support/fragments/finance/budgets/budgets';
 import FinanceHelp from '../../support/fragments/finance/financeHelper';
 import FiscalYears from '../../support/fragments/finance/fiscalYears/fiscalYears';
+import FundDetails from '../../support/fragments/finance/funds/fundDetails';
 import Funds from '../../support/fragments/finance/funds/funds';
 import Ledgers from '../../support/fragments/finance/ledgers/ledgers';
+import TransactionDetails from '../../support/fragments/finance/transactions/transactionDetails';
+import Transactions from '../../support/fragments/finance/transactions/transactions';
 import Invoices from '../../support/fragments/invoices/invoices';
+import InvoiceDetails from '../../support/fragments/invoices/invoiceView';
 import BasicOrderLine from '../../support/fragments/orders/basicOrderLine';
 import NewOrder from '../../support/fragments/orders/newOrder';
+import OrderLineDetails from '../../support/fragments/orders/orderLineDetails';
 import OrderLines from '../../support/fragments/orders/orderLines';
 import Orders from '../../support/fragments/orders/orders';
 import NewOrganization from '../../support/fragments/organizations/newOrganization';
@@ -21,10 +26,10 @@ import NewLocation from '../../support/fragments/settings/tenant/locations/newLo
 import ServicePoints from '../../support/fragments/settings/tenant/servicePoints/servicePoints';
 import TopMenuNavigation from '../../support/fragments/topMenuNavigation';
 import Users from '../../support/fragments/users/users';
-import getRandomPostfix from '../../support/utils/stringTools';
 import InteractorsTools from '../../support/utils/interactorsTools';
+import getRandomPostfix from '../../support/utils/stringTools';
 
-describe('orders: Unopen order', () => {
+describe('orders: Unopen order', { retries: { runMode: 1 } }, () => {
   const order = { ...NewOrder.defaultOngoingTimeOrder, approved: true, reEncumber: true };
   const organization = {
     ...NewOrganization.defaultUiOrganizations,
@@ -205,22 +210,29 @@ describe('orders: Unopen order', () => {
     'C375106 Unopen order with changed Fund distribution when related paid invoice exists (thunderjet)',
     { tags: ['criticalPath', 'thunderjet', 'shiftLeft', 'eurekaPhase1'] },
     () => {
+      /* Orders app */
       Orders.searchByParameter('PO number', orderNumber);
       Orders.selectFromResultsList(orderNumber);
       Orders.unOpenOrder();
-      OrderLines.selectPOLInOrder(0);
-      cy.wait(5000);
+      OrderLines.selectPOLInOrder(0); // Order details -> PO Line details
+      OrderLineDetails.waitLoading();
       OrderLines.checkFundInPOL(secondFund);
-      OrderLines.backToEditingOrder();
+      OrderLines.backToEditingOrder(); // Order Line details -> Order details
       Orders.openOrder();
-      OrderLines.selectPOLInOrder(0);
+      OrderLines.selectPOLInOrder(0); // Order details -> PO Line details
+      OrderLineDetails.waitLoading();
       OrderLines.checkFundInPOL(secondFund);
-      TopMenuNavigation.navigateToApp('Finance');
+      TopMenuNavigation.navigateToApp('Finance'); // Order Line details -> Finance app
+
+      /* Finance app */
       FinanceHelp.searchByName(secondFund.name);
-      Funds.selectFund(secondFund.name);
-      Funds.selectBudgetDetails();
-      Funds.viewTransactions();
+      Funds.selectFund(secondFund.name); // Funds results -> Fund details
+      FundDetails.waitLoading();
+      Funds.selectBudgetDetails(); // Fund details -> Budget details
+      Funds.viewTransactions(); // Budget details -> Transactions
+      Transactions.waitLoading();
       Funds.selectTransactionInList('Encumbrance');
+      TransactionDetails.waitLoading();
       Funds.varifyDetailsInTransaction(
         defaultFiscalYear.code,
         '$0.00',
@@ -229,19 +241,25 @@ describe('orders: Unopen order', () => {
         `${secondFund.name} (${secondFund.code})`,
       );
       InteractorsTools.closeAllVisibleCallouts();
-      Funds.closeTransactionDetails();
+      Funds.closeTransactionDetails(); // Transactions -> Budget details
       Funds.closePaneHeader();
-      Funds.closeBudgetDetails();
-      Funds.closeFundDetails();
+      Funds.closeBudgetDetails(); // Budget details -> Fund details
+      Funds.closeFundDetails(); // Fund details -> Funds results
       TopMenuNavigation.navigateToApp('Invoices');
+
+      /* Invoices app */
       Invoices.searchByNumber(firstInvoice.vendorInvoiceNo);
-      Invoices.selectInvoice(firstInvoice.vendorInvoiceNo);
-      Invoices.selectInvoiceLine();
+      Invoices.selectInvoice(firstInvoice.vendorInvoiceNo); // Invoices results -> Invoice details
+      InvoiceDetails.waitLoading();
+      Invoices.selectInvoiceLine(); // Invoice details -> Invoice line details
       TopMenuNavigation.navigateToApp('Finance');
+
+      /* Finance app */
       FinanceHelp.searchByName(firstFund.name);
-      Funds.selectFund(firstFund.name);
-      Funds.selectBudgetDetails();
-      Funds.viewTransactions();
+      Funds.selectFund(firstFund.name); // Funds results -> Fund details
+      FundDetails.waitLoading();
+      Funds.selectBudgetDetails(); // Fund details -> Budget details
+      Funds.viewTransactions(); // Budget details -> Transactions
       Funds.selectTransactionInList('Payment');
       Funds.varifyDetailsInTransaction(
         defaultFiscalYear.code,

--- a/cypress/e2e/orders/unrelease-encumbrances-when-reopen-unreceived-order.cy.js
+++ b/cypress/e2e/orders/unrelease-encumbrances-when-reopen-unreceived-order.cy.js
@@ -1,27 +1,30 @@
+import {
+  ACQUISITION_METHOD_NAMES_IN_PROFILE,
+  INVOICE_STATUSES,
+  ORDER_STATUSES,
+} from '../../support/constants';
 import permissions from '../../support/dictionary/permissions';
+import BudgetDetails from '../../support/fragments/finance/budgets/budgetDetails';
+import Budgets from '../../support/fragments/finance/budgets/budgets';
 import Helper from '../../support/fragments/finance/financeHelper';
 import FiscalYears from '../../support/fragments/finance/fiscalYears/fiscalYears';
+import FundDetails from '../../support/fragments/finance/funds/fundDetails';
 import Funds from '../../support/fragments/finance/funds/funds';
 import Ledgers from '../../support/fragments/finance/ledgers/ledgers';
+import Transactions from '../../support/fragments/finance/transactions/transactions';
 import Invoices from '../../support/fragments/invoices/invoices';
+import BasicOrderLine from '../../support/fragments/orders/basicOrderLine';
 import NewOrder from '../../support/fragments/orders/newOrder';
 import OrderDetails from '../../support/fragments/orders/orderDetails';
 import OrderLines from '../../support/fragments/orders/orderLines';
 import Orders from '../../support/fragments/orders/orders';
 import NewOrganization from '../../support/fragments/organizations/newOrganization';
 import Organizations from '../../support/fragments/organizations/organizations';
+import MaterialTypes from '../../support/fragments/settings/inventory/materialTypes';
 import NewLocation from '../../support/fragments/settings/tenant/locations/newLocation';
 import ServicePoints from '../../support/fragments/settings/tenant/servicePoints/servicePoints';
 import TopMenu from '../../support/fragments/topMenu';
 import Users from '../../support/fragments/users/users';
-import Budgets from '../../support/fragments/finance/budgets/budgets';
-import {
-  ACQUISITION_METHOD_NAMES_IN_PROFILE,
-  INVOICE_STATUSES,
-  ORDER_STATUSES,
-} from '../../support/constants';
-import BasicOrderLine from '../../support/fragments/orders/basicOrderLine';
-import MaterialTypes from '../../support/fragments/settings/inventory/materialTypes';
 
 describe('Orders', () => {
   const defaultFiscalYear = { ...FiscalYears.defaultUiFiscalYear };
@@ -166,14 +169,22 @@ describe('Orders', () => {
     'C358539 Unrelease encumbrances when reopen unreceived ongoing order with related paid invoice (Release encumbrance =true) (thunderjet)',
     { tags: ['criticalPath', 'thunderjet', 'eurekaPhase1'] },
     () => {
+      /* Orders app */
       Orders.searchByParameter('PO number', orderNumber);
+      Orders.waitLoading();
       Orders.selectFromResultsList(orderNumber);
+      OrderDetails.waitLoading();
       OrderDetails.reOpenOrder({ orderNumber });
       cy.visit(TopMenu.fundPath);
+
+      /* Finance app */
       Helper.searchByName(defaultFund.name);
       Funds.selectFund(defaultFund.name);
-      Funds.selectBudgetDetails();
-      Funds.openTransactions();
+      FundDetails.waitLoading();
+      Funds.selectBudgetDetails(); // Fund details -> Budget details
+      BudgetDetails.waitLoading();
+      Funds.openTransactions(); // Budget details -> Transactions
+      Transactions.waitLoading();
       Funds.selectTransactionInList('Encumbrance');
       Funds.checkStatusInTransactionDetails('Unreleased');
     },

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -1350,3 +1350,5 @@ export const STANDARD_FIELDS = [
 ];
 
 export const SYSTEM_FIELDS = ['000', '001', '005', '008', '999'];
+
+export const DEFAULT_WAIT_TIME = 4000;

--- a/cypress/support/fragments/finance/budgets/budgetDetails.js
+++ b/cypress/support/fragments/finance/budgets/budgetDetails.js
@@ -8,9 +8,10 @@ import {
   Section,
   including,
 } from '../../../../../interactors';
-import { TRANSFER_ACTIONS } from '../transfer/constants';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import FinanceDetails from '../financeDetails';
 import AddTransferModal from '../modals/addTransferModal';
+import { TRANSFER_ACTIONS } from '../transfer/constants';
 import Transactions from '../transactions/transactions';
 
 const budgetPane = Section({ id: 'pane-budget' });
@@ -22,8 +23,8 @@ const informationSection = budgetPane.find(Section({ id: 'information' }));
 const expenseClassSection = budgetPane.find(Section({ id: 'expense-classes' }));
 
 export default {
-  waitLoading() {
-    cy.wait(4000);
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(budgetPane.exists());
   },
   checkBudgetDetails({ summary = [], information = [], balance = {}, expenseClass } = {}) {

--- a/cypress/support/fragments/finance/fiscalYears/fiscalYearDetails.js
+++ b/cypress/support/fragments/finance/fiscalYears/fiscalYearDetails.js
@@ -1,5 +1,6 @@
 import { Button, PaneHeader, Section, including } from '../../../../../interactors';
 import { AppList } from '../../../../../interactors/applist';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import FinanceDetails from '../financeDetails';
 import LedgerDetails from '../ledgers/ledgerDetails';
 
@@ -8,7 +9,8 @@ const fiscalYearDetailsHeader = PaneHeader({ id: 'paneHeaderpane-fiscal-year-det
 
 export default {
   ...FinanceDetails,
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(fiscalYearDetailsSection.exists());
   },
   checkFiscalYearDetails({ information, financialSummary, ledgers, groups, funds } = {}) {

--- a/cypress/support/fragments/finance/funds/fundDetails.js
+++ b/cypress/support/fragments/finance/funds/fundDetails.js
@@ -5,11 +5,12 @@ import {
   Section,
   including,
 } from '../../../../../interactors';
-import FinanceDetails from '../financeDetails';
-import FundEditForm from './fundEditForm';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import BudgetDetails from '../budgets/budgetDetails';
+import FinanceDetails from '../financeDetails';
 import AddBudgetModal from '../modals/addBudgetModal';
 import Transactions from '../transactions/transactions';
+import FundEditForm from './fundEditForm';
 
 const fundDetailsPane = Section({ id: 'pane-fund-details' });
 
@@ -26,8 +27,8 @@ const previousBudgetsSection = fundDetailsPane.find(Section({ id: 'previousBudge
 
 export default {
   ...FinanceDetails,
-  waitLoading: () => {
-    cy.wait(4000);
+  waitLoading: (ms = DEFAULT_WAIT_TIME) => {
+    cy.wait(ms);
     cy.expect(fundDetailsPane.exists());
   },
   expandActionsDropdown() {

--- a/cypress/support/fragments/finance/funds/fundEditForm.js
+++ b/cypress/support/fragments/finance/funds/fundEditForm.js
@@ -9,9 +9,10 @@ import {
   TextField,
   including,
 } from '../../../../../interactors';
-import States from '../states';
-import AddDonorsModal from '../modals/addDonorsModal';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import InteractorsTools from '../../../utils/interactorsTools';
+import AddDonorsModal from '../modals/addDonorsModal';
+import States from '../states';
 
 const fundEditForm = Section({ id: 'pane-fund-form' });
 
@@ -42,7 +43,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(fundEditForm.exists());
   },
   verifyFormView() {

--- a/cypress/support/fragments/finance/groups/groupDetails.js
+++ b/cypress/support/fragments/finance/groups/groupDetails.js
@@ -1,12 +1,14 @@
-import FinanceDetails from '../financeDetails';
 import { PaneHeader, Section, including } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
+import FinanceDetails from '../financeDetails';
 
 const groupDetailsPane = Section({ id: 'pane-group-details' });
 const groupDetailsPaneHeader = PaneHeader({ id: 'paneHeaderpane-group-details' });
 
 export default {
   ...FinanceDetails,
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(groupDetailsPane.exists());
   },
   verifyGroupName: (title) => {

--- a/cypress/support/fragments/finance/ledgers/ledgerDetails.js
+++ b/cypress/support/fragments/finance/ledgers/ledgerDetails.js
@@ -1,10 +1,11 @@
 import { Button, PaneHeader, Section, including } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import FinanceDetails from '../financeDetails';
-import LedgerRollovers from './ledgerRollovers';
-import LedgerRolloverDetails from './ledgerRolloverDetails';
-import GroupDetails from '../groups/groupDetails';
 import FundDetails from '../funds/fundDetails';
+import GroupDetails from '../groups/groupDetails';
 import ExportBudgetModal from '../modals/exportBudgetModal';
+import LedgerRolloverDetails from './ledgerRolloverDetails';
+import LedgerRollovers from './ledgerRollovers';
 
 const ledgerDetailsPane = Section({ id: 'pane-ledger-details' });
 
@@ -14,7 +15,8 @@ const actionsButton = Button('Actions');
 
 export default {
   ...FinanceDetails,
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(ledgerDetailsPane.exists());
   },
   expandActionsDropdown() {

--- a/cypress/support/fragments/finance/ledgers/ledgers.js
+++ b/cypress/support/fragments/finance/ledgers/ledgers.js
@@ -1,4 +1,5 @@
 import uuid from 'uuid';
+
 import {
   Button,
   Accordion,
@@ -18,10 +19,11 @@ import {
   HTML,
   including,
 } from '../../../../../interactors';
-import LedgerDetails from './ledgerDetails';
-import FinanceHelper from '../financeHelper';
-import getRandomPostfix from '../../../utils/stringTools';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import InteractorsTools from '../../../utils/interactorsTools';
+import getRandomPostfix from '../../../utils/stringTools';
+import FinanceHelper from '../financeHelper';
+import LedgerDetails from './ledgerDetails';
 
 const createdLedgerNameXpath = '//*[@id="paneHeaderpane-ledger-details-pane-title"]/h2/span';
 const numberOfSearchResultsHeader = '//*[@id="paneHeaderledger-results-pane-subtitle"]/span';
@@ -1367,7 +1369,8 @@ export default {
     });
   },
 
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect([ledgerResultsPaneSection.exists(), ledgersFiltersSection.exists()]);
   },
 

--- a/cypress/support/fragments/finance/transactions/transactionDetails.js
+++ b/cypress/support/fragments/finance/transactions/transactionDetails.js
@@ -7,6 +7,7 @@ import {
   including,
   Link,
 } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 
 const transactionDetailSection = Section({ id: 'pane-transaction-details' });
 const transactionDetailsPaneHeader = PaneHeader({ id: 'paneHeaderpane-transaction-details' });
@@ -14,8 +15,8 @@ const transactionDetailsPaneHeader = PaneHeader({ id: 'paneHeaderpane-transactio
 const informationSection = Section({ id: 'information' });
 
 export default {
-  waitLoading() {
-    cy.wait(4000);
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(transactionDetailSection.exists());
   },
   checkTransactionDetails({ information = [] } = {}) {

--- a/cypress/support/fragments/finance/transactions/transactions.js
+++ b/cypress/support/fragments/finance/transactions/transactions.js
@@ -6,13 +6,15 @@ import {
   Section,
   including,
 } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import TransactionDetails from './transactionDetails';
 
 const transactionResultsPane = Section({ id: 'transaction-results-pane' });
 const transactionResultsList = MultiColumnList({ id: 'transactions-list' });
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(transactionResultsPane.exists());
   },
   checkTransactionsList({ records = [], present = true } = {}) {

--- a/cypress/support/fragments/invoices/invoiceEditForm.js
+++ b/cypress/support/fragments/invoices/invoiceEditForm.js
@@ -12,10 +12,11 @@ import {
   FieldSet,
   including,
 } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
+import { getLongDelay } from '../../utils/cypressTools';
 import InteractorsTools from '../../utils/interactorsTools';
 import FinanceHelper from '../finance/financeHelper';
 import InvoiceStates from './invoiceStates';
-import { getLongDelay } from '../../utils/cypressTools';
 
 const invoiceEditFormRoot = Section({ id: 'pane-invoice-form' });
 const informationSection = invoiceEditFormRoot.find(Section({ id: 'invoiceForm-information' }));
@@ -57,7 +58,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(invoiceEditFormRoot.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/invoices/invoiceLineDetails.js
+++ b/cypress/support/fragments/invoices/invoiceLineDetails.js
@@ -12,9 +12,10 @@ import {
   including,
   matching,
 } from '../../../../interactors';
-import InvoiceLineEditForm from './invoiceLineEditForm';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import FundDetails from '../finance/funds/fundDetails';
 import TransactionDetails from '../finance/transactions/transactionDetails';
+import InvoiceLineEditForm from './invoiceLineEditForm';
 
 // invoice lines details
 const invoiceLineDetailsPane = Pane({ id: 'pane-invoiceLineDetails' });
@@ -35,8 +36,8 @@ const relatedInvoiceLinesSection = invoiceLineDetailsPane.find(
 );
 
 export default {
-  waitLoading() {
-    cy.wait(4000);
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(invoiceLineDetailsPaneHeader.exists());
   },
   openInvoiceLineEditForm() {

--- a/cypress/support/fragments/invoices/invoiceLineEditForm.js
+++ b/cypress/support/fragments/invoices/invoiceLineEditForm.js
@@ -8,6 +8,7 @@ import {
   TextField,
   including,
 } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
 import FinanceHelper from '../finance/financeHelper';
 import InvoiceStates from './invoiceStates';
@@ -44,7 +45,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(invoiceLineEditFormRoot.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/invoices/invoiceView.js
+++ b/cypress/support/fragments/invoices/invoiceView.js
@@ -12,6 +12,7 @@ import {
   PaneHeader,
   Section,
 } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import interactorsTools from '../../utils/interactorsTools';
 import InvoiceEditForm from './invoiceEditForm';
 import InvoiceLineDetails from './invoiceLineDetails';
@@ -41,6 +42,10 @@ const voucherInformationSection = invoiceDetailsPane.find(Section({ id: 'voucher
 const vendorDetailsSection = invoiceDetailsPane.find(Section({ id: 'vendorDetails' }));
 
 export default {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
+    cy.expect(invoiceDetailsPane.exists());
+  },
   expandActionsDropdown() {
     cy.wait(4000);
     cy.do(invoiceDetailsPaneHeader.find(actionsButton).click());

--- a/cypress/support/fragments/orders/modals/changeInstanceModal.js
+++ b/cypress/support/fragments/orders/modals/changeInstanceModal.js
@@ -1,4 +1,5 @@
 import { Button, Modal, Select, matching } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import InteractorsTools from '../../../utils/interactorsTools';
 import OrderStates from '../orderStates';
 
@@ -11,7 +12,8 @@ const content =
   'You have changed the title information of this purchase order line from (?:\\S+) to (?:\\S+). All related item records will be moved to the new instance. How would you like to address the related Holdings?';
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(changeInstanceModal.exists());
   },
   verifyModalView() {

--- a/cypress/support/fragments/orders/modals/selectInstanceModal.js
+++ b/cypress/support/fragments/orders/modals/selectInstanceModal.js
@@ -9,6 +9,7 @@ import {
   Select,
   not,
 } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import ChangeInstanceModal from './changeInstanceModal';
 
 const selectInstanceModal = Modal('Select instance');
@@ -71,7 +72,8 @@ const searchItemsOptions = [
 ];
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(selectInstanceModal.exists());
   },
   verifyModalView() {

--- a/cypress/support/fragments/orders/modals/selectLocationModal.js
+++ b/cypress/support/fragments/orders/modals/selectLocationModal.js
@@ -1,9 +1,11 @@
 import { Button, Modal, MultiColumnListCell, TextField } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 
 const selectLocationModal = Modal('Select locations');
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(selectLocationModal.exists());
   },
   verifyModalView() {

--- a/cypress/support/fragments/orders/orderDetails.js
+++ b/cypress/support/fragments/orders/orderDetails.js
@@ -1,29 +1,30 @@
 import {
+  Accordion,
   Button,
+  Checkbox,
+  including,
+  KeyValue,
+  Link,
+  MultiColumnList,
+  MultiColumnListCell,
+  MultiColumnListRow,
   Pane,
   PaneHeader,
   Section,
-  KeyValue,
-  MultiColumnListCell,
-  MultiColumnListRow,
-  including,
-  Link,
-  Checkbox,
-  Accordion,
-  MultiColumnList,
 } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
-import OrderEditForm from './orderEditForm';
-import OrderLines from './orderLines';
-import OrderLineDetails from './orderLineDetails';
-import OrderLineEditForm from './orderLineEditForm';
+import ExportDetails from '../exportManager/exportDetails';
 import InventoryInstance from '../inventory/inventoryInstance';
+import Receivings from '../receiving/receiving';
+import CloseConfirmationModal from './modals/closeConfirmationModal';
 import CreateInvoiceModal from './modals/createInvoiceModal';
 import OpenConfirmationModal from './modals/openConfirmationModal';
 import UnopenConfirmationModal from './modals/unopenConfirmationModal';
-import ExportDetails from '../exportManager/exportDetails';
-import Receivings from '../receiving/receiving';
-import CloseConfirmationModal from './modals/closeConfirmationModal';
+import OrderEditForm from './orderEditForm';
+import OrderLineDetails from './orderLineDetails';
+import OrderLineEditForm from './orderLineEditForm';
+import OrderLines from './orderLines';
 
 const orderDetailsPane = Pane({ id: 'order-details' });
 const actionsButton = Button('Actions');
@@ -50,6 +51,10 @@ const openPolDetails = (title) => {
 };
 
 export default {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
+    cy.expect(orderDetailsPane.exists());
+  },
   openPolDetails,
   checkOrderStatus(orderStatus) {
     cy.expect(poSummarySection.find(KeyValue('Workflow status')).has({ value: orderStatus }));

--- a/cypress/support/fragments/orders/orderEditForm.js
+++ b/cypress/support/fragments/orders/orderEditForm.js
@@ -10,9 +10,10 @@ import {
   including,
   matching,
 } from '../../../../interactors';
-import OrderStates from './orderStates';
-import SearchHelper from '../finance/financeHelper';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
+import SearchHelper from '../finance/financeHelper';
+import OrderStates from './orderStates';
 
 const orderEditFormRoot = Section({ id: 'pane-poForm' });
 
@@ -55,7 +56,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(orderEditFormRoot.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/orders/orderLineDetails.js
+++ b/cypress/support/fragments/orders/orderLineDetails.js
@@ -11,14 +11,15 @@ import {
   Warning,
   including,
 } from '../../../../interactors';
-import CancelConfirmationModal from './modals/cancelConfirmationModal';
-import OrderLineEditForm from './orderLineEditForm';
-import InventoryInstance from '../inventory/inventoryInstance';
-import TransactionDetails from '../finance/transactions/transactionDetails';
-import ExportDetails from '../exportManager/exportDetails';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
-import VersionHistory from './orderVersionHistory';
+import ExportDetails from '../exportManager/exportDetails';
+import TransactionDetails from '../finance/transactions/transactionDetails';
+import InventoryInstance from '../inventory/inventoryInstance';
+import CancelConfirmationModal from './modals/cancelConfirmationModal';
 import SelectInstanceModal from './modals/selectInstanceModal';
+import OrderLineEditForm from './orderLineEditForm';
+import VersionHistory from './orderVersionHistory';
 
 const orderLineDetailsSection = Section({ id: 'order-lines-details' });
 const paneHeaderOrderLinesDetailes = orderLineDetailsSection.find(
@@ -43,7 +44,8 @@ const linkedInstancesDetailsSection = orderLineDetailsSection.find(
 );
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(orderLineDetailsSection.exists());
   },
   backToOrderDetails() {

--- a/cypress/support/fragments/orders/orderLineEditForm.js
+++ b/cypress/support/fragments/orders/orderLineEditForm.js
@@ -12,10 +12,11 @@ import {
   including,
   matching,
 } from '../../../../interactors';
-import OrderStates from './orderStates';
+import { DEFAULT_WAIT_TIME } from '../../constants';
+import InteractorsTools from '../../utils/interactorsTools';
 import SelectInstanceModal from './modals/selectInstanceModal';
 import SelectLocationModal from './modals/selectLocationModal';
-import InteractorsTools from '../../utils/interactorsTools';
+import OrderStates from './orderStates';
 
 const orderLineEditFormRoot = Section({ id: 'pane-poLineForm' });
 const itemDetailsSection = orderLineEditFormRoot.find(Section({ id: 'itemDetails' }));
@@ -75,7 +76,8 @@ const disabledButtons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(orderLineEditFormRoot.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/orders/orderLines.js
+++ b/cypress/support/fragments/orders/orderLines.js
@@ -177,8 +177,8 @@ export default {
   clickOnOrderLines: () => {
     cy.do([orderLineButton.click()]);
   },
-  waitLoading() {
-    cy.wait(6000);
+  waitLoading(ms = 6000) {
+    cy.wait(ms);
     cy.expect([
       Pane({ id: 'order-lines-filters-pane' }).exists(),
       Pane({ id: 'order-lines-results-pane' }).exists(),

--- a/cypress/support/fragments/orders/orderVersionHistory.js
+++ b/cypress/support/fragments/orders/orderVersionHistory.js
@@ -1,11 +1,13 @@
 import { Button, including, Section, Card } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 
 const versionsHistoryOrderLineSection = Section({ id: 'versions-history-pane-order-line' });
 const iconClock = Button({ icon: 'clock' });
 const iconTimes = Button({ icon: 'times' });
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(versionsHistoryOrderLineSection.exists());
   },
   veriifyIconClockExists() {

--- a/cypress/support/fragments/orders/orders.js
+++ b/cypress/support/fragments/orders/orders.js
@@ -1,38 +1,38 @@
 import {
-  Button,
-  SearchField,
-  PaneHeader,
-  Pane,
-  Select,
   Accordion,
-  KeyValue,
+  Button,
+  Card,
   Checkbox,
+  HTML,
+  including,
+  KeyValue,
+  Link,
+  Modal,
   MultiColumnList,
   MultiColumnListCell,
   MultiColumnListRow,
-  Modal,
-  TextField,
-  HTML,
-  including,
-  SelectionOption,
   MultiSelect,
   MultiSelectOption,
-  Link,
-  Section,
-  Card,
+  Pane,
   PaneContent,
+  PaneHeader,
+  SearchField,
+  Section,
+  Select,
+  SelectionOption,
   Spinner,
+  TextField,
 } from '../../../../interactors';
-import { ORDER_SYSTEM_CLOSING_REASONS } from '../../constants';
-import SearchHelper from '../finance/financeHelper';
-import InteractorsTools from '../../utils/interactorsTools';
+import { DEFAULT_WAIT_TIME, ORDER_SYSTEM_CLOSING_REASONS } from '../../constants';
 import { getLongDelay } from '../../utils/cypressTools';
 import DateTools from '../../utils/dateTools';
 import FileManager from '../../utils/fileManager';
-import OrderDetails from './orderDetails';
-import OrderEditForm from './orderEditForm';
+import InteractorsTools from '../../utils/interactorsTools';
+import SearchHelper from '../finance/financeHelper';
 import ExportSettingsModal from './modals/exportSettingsModal';
 import UnopenConfirmationModal from './modals/unopenConfirmationModal';
+import OrderDetails from './orderDetails';
+import OrderEditForm from './orderEditForm';
 import OrderLines from './orderLines';
 
 const numberOfSearchResultsHeader = '//*[@id="paneHeaderorders-results-pane-subtitle"]/span';
@@ -82,7 +82,8 @@ export default {
   clearSearchField() {
     cy.get('#orders-filters-pane-content').find('#input-record-search').clear();
   },
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect([ordersFiltersPane.exists(), ordersResultsPane.exists()]);
   },
 

--- a/cypress/support/fragments/organizations/integrations/integrationEditForm.js
+++ b/cypress/support/fragments/organizations/integrations/integrationEditForm.js
@@ -1,8 +1,9 @@
 import moment from 'moment';
 
 import { Button, Checkbox, Section, Select, TextField } from '../../../../../interactors';
-import IntegrationStates from './integrationStates';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import InteractorsTools from '../../../utils/interactorsTools';
+import IntegrationStates from './integrationStates';
 
 const integrationViewForm = Section({ id: 'integration-form' });
 
@@ -38,7 +39,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(integrationViewForm.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/organizations/integrations/integrationViewForm.js
+++ b/cypress/support/fragments/organizations/integrations/integrationViewForm.js
@@ -1,4 +1,5 @@
 import { Button, Section } from '../../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import IntegrationEditForm from './integrationEditForm';
 
 const integrationViewForm = Section({ id: 'integration-view' });
@@ -7,7 +8,8 @@ const actionsButton = Button('Actions');
 const editButton = Button('Edit');
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(integrationViewForm.exists());
   },
   openIntegrationEditForm() {

--- a/cypress/support/fragments/organizations/organizationDetails.js
+++ b/cypress/support/fragments/organizations/organizationDetails.js
@@ -1,4 +1,5 @@
 import { Button, MultiColumnList, MultiColumnListCell, Section } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import IntegrationViewForm from './integrations/integrationViewForm';
 
 const organizationDetailsSection = Section({ id: 'pane-organization-details' });
@@ -13,7 +14,8 @@ const listIntegrationConfigs = MultiColumnList({
 });
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(organizationDetailsSection.exists());
   },
   organizationDetailsSectionIsAbsent() {

--- a/cypress/support/fragments/receiving/receiving.js
+++ b/cypress/support/fragments/receiving/receiving.js
@@ -1,4 +1,5 @@
 import { HTML, including } from '@interactors/html';
+
 import {
   Accordion,
   Button,
@@ -15,6 +16,7 @@ import {
   Select,
   TextField,
 } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
 import ExportSettingsModal from './modals/exportSettingsModal';
 import ReceivingDetails from './receivingDetails';
@@ -39,7 +41,8 @@ const filterOpenReceiving = () => {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect([
       Pane({ id: 'receiving-filters-pane' }).exists(),
       Pane({ id: 'receiving-results-pane' }).exists(),

--- a/cypress/support/fragments/receiving/receivingDetails.js
+++ b/cypress/support/fragments/receiving/receivingDetails.js
@@ -6,11 +6,12 @@ import {
   MultiColumnListCell,
   Link,
 } from '../../../../interactors';
-import ReceivingsListEditForm from './receivingsListEditForm';
-import ReceivingEditForm from './receivingEditForm';
-import EditPieceModal from './modals/editPieceModal';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InventoryInstance from '../inventory/inventoryInstance';
 import OrderLineDetails from '../orders/orderLineDetails';
+import EditPieceModal from './modals/editPieceModal';
+import ReceivingEditForm from './receivingEditForm';
+import ReceivingsListEditForm from './receivingsListEditForm';
 
 const receivingDetailsSection = Section({ id: 'pane-title-details' });
 const instanceDetailsLink = receivingDetailsSection.find(
@@ -27,7 +28,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(receivingDetailsSection.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/receiving/receivingEditForm.js
+++ b/cypress/support/fragments/receiving/receivingEditForm.js
@@ -1,6 +1,7 @@
 import { Button, Section, TextField, matching } from '../../../../interactors';
-import ReceivingStates from './receivingStates';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
+import ReceivingStates from './receivingStates';
 
 const receivingEditForm = Section({ id: 'pane-title-form' });
 const itemDetailsSection = receivingEditForm.find(Section({ id: 'itemDetails' }));
@@ -21,7 +22,8 @@ const cancelButton = receivingEditForm.find(Button('Cancel'));
 const saveAndCloseButton = receivingEditForm.find(Button('Save & close'));
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(receivingEditForm.exists());
   },
   checkReceivingFormContent({ itemDetails, lineDetails }) {

--- a/cypress/support/fragments/receiving/receivingsListEditForm.js
+++ b/cypress/support/fragments/receiving/receivingsListEditForm.js
@@ -7,9 +7,10 @@ import {
   TextField,
   including,
 } from '../../../../interactors';
+import { DEFAULT_WAIT_TIME } from '../../constants';
 import InteractorsTools from '../../utils/interactorsTools';
-import ReceivingStates from './receivingStates';
 import SelectLocationModal from '../orders/modals/selectLocationModal';
+import ReceivingStates from './receivingStates';
 
 const receivingsListEditForm = Section({ id: 'pane-title-receive-list' });
 const receinigsListTable = receivingsListEditForm.find(HTML({ id: 'title-receive-list' }));
@@ -23,7 +24,8 @@ const buttons = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(receivingsListEditForm.exists());
   },
   checkButtonsConditions(fields = []) {

--- a/cypress/support/fragments/settings/orders/orderTemplateForm.js
+++ b/cypress/support/fragments/settings/orders/orderTemplateForm.js
@@ -9,8 +9,9 @@ import {
   TextArea,
   TextField,
 } from '../../../../../interactors';
-import SearchHelper from '../../finance/financeHelper';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import InteractorsTools from '../../../utils/interactorsTools';
+import SearchHelper from '../../finance/financeHelper';
 
 const orderTemplateForm = Form({ id: 'order-template-form' });
 const orderTemplateInfoSection = orderTemplateForm.find(Section({ id: 'templateInfo' }));
@@ -68,7 +69,8 @@ const sections = {
 };
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(orderTemplateForm.exists());
   },
   checkOrderTemplateFormContent() {

--- a/cypress/support/fragments/settings/orders/orderTemplates.js
+++ b/cypress/support/fragments/settings/orders/orderTemplates.js
@@ -1,13 +1,16 @@
 import uuid from 'uuid';
+
 import { Button, DropdownMenu, NavListItem, Pane, PaneContent } from '../../../../../interactors';
-import OrderTemplateForm from './orderTemplateForm';
-import getRandomPostfix from '../../../utils/stringTools';
+import { DEFAULT_WAIT_TIME } from '../../../constants';
 import InteractorsTools from '../../../utils/interactorsTools';
+import getRandomPostfix from '../../../utils/stringTools';
+import OrderTemplateForm from './orderTemplateForm';
 
 const actionsButton = Button('Actions');
 
 export default {
-  waitLoading() {
+  waitLoading(ms = DEFAULT_WAIT_TIME) {
+    cy.wait(ms);
     cy.expect(Pane({ id: 'order-settings-order-templates-list' }).exists());
   },
 


### PR DESCRIPTION
Most of *flaky* tests fail because they can't find some pane/section by ID, because it's in loading status. Waiters should decrease the number of cases where the target source is loading.