### PR TITLE
FAT-21508-C17136-fix

### DIFF
--- a/cypress/e2e/users/loans/manual-anonymization-closed-loans.cy.js
+++ b/cypress/e2e/users/loans/manual-anonymization-closed-loans.cy.js
@@ -210,12 +210,12 @@ describe('Loans', () => {
           waiter: SearchPane.waitLoading,
         });
         SearchPane.setFilterOptionFromAccordion('loan', searchResultsData.circAction);
-        SearchPane.findResultRowIndexByContent(searchResultsData.circAction).then((rowIndex) => {
+        SearchPane.findResultRowIndexByContent(searchResultsData.itemBarcode).then((rowIndex) => {
           SearchPane.checkResultSearch(searchResultsData, rowIndex);
         });
         SearchPane.resetResults();
         SearchPane.searchByItemBarcode(testData.itemBarcodes[1]);
-        SearchPane.findResultRowIndexByContent(searchResultsData.circAction).then((rowIndex) => {
+        SearchPane.findResultRowIndexByContent(searchResultsData.itemBarcode).then((rowIndex) => {
           SearchPane.checkResultSearch(searchResultsData, rowIndex);
         });
       },


### PR DESCRIPTION
## Description
Use `itemBarcode` instead of `circAction` to find the correct row. The item barcode is a unique field, and `circAction` is not.