### PR TITLE
FAT-21831: waitForAuthRefresh method update

### DIFF
--- a/cypress/support/api/auth.js
+++ b/cypress/support/api/auth.js
@@ -109,13 +109,6 @@ Cypress.Commands.add('updateCredentials', (username, oldPassword, newPassword, u
   });
 });
 
-// Cypress.Commands.add('waitForAuthRefresh', (callback, timeout = 20_000) => {
-//   cy.intercept('POST', '/authn/refresh').as('/authn/refresh');
-//   callback();
-//   cy.wait('@/authn/refresh', { timeout }).its('response.statusCode').should('eq', 201);
-//   cy.wait(500);
-// });
-
 Cypress.Commands.add('waitForAuthRefresh', (callback, timeout = 20_000) => {
   authRefreshCounter++;
   const alias = `authnRefreshCall_${authRefreshCounter}`;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FAT-21831
waitForAuthRefresh() method needs to be updated to not fail if refresh call was not made within expected time range