### PR TITLE
C16994 fix double slash on okapi request

### DIFF
--- a/cypress/support/fragments/eholdings/eHoldingsTitle.js
+++ b/cypress/support/fragments/eholdings/eHoldingsTitle.js
@@ -130,7 +130,7 @@ export default {
     this.getTitleIdFromUrl().then((id) => {
       cy.okapiRequest({
         method: 'GET',
-        path: `/eholdings/titles/${id}`,
+        path: `eholdings/titles/${id}`,
         searchParams: {
           include: 'resources',
         },
@@ -156,7 +156,7 @@ export default {
           };
           cy.okapiRequest({
             method: 'PUT',
-            path: `/eholdings/resources/${resourceId}`,
+            path: `eholdings/resources/${resourceId}`,
             body: payload,
             contentTypeHeader: 'application/vnd.api+json',
           });


### PR DESCRIPTION
## Description
Fix C16994. Okapi request was being sent with an extra slash in the path. The issue was that `cy.okapiRequest` adds a slash between hostname and pathname, but `changePackageStatusViaApi` also included a slash in the pathname, resulting in two slashes
