### PR TITLE
C411840 Inactive lists

### DIFF
--- a/cypress/e2e/lists/inactive-lists-details-page.cy.js
+++ b/cypress/e2e/lists/inactive-lists-details-page.cy.js
@@ -1,0 +1,128 @@
+import { DEFAULT_JOB_PROFILE_NAMES } from '../../../support/constants';
+import Permissions from '../../../support/dictionary/permissions';
+import Lists from '../../../support/fragments/lists/lists';
+import TopMenu from '../../../support/fragments/topMenuNavigation';
+import Users from '../../../support/fragments/users/users';
+import { getTestEntityValue } from '../../../support/utils/stringTools';
+
+describe('Lists', () => {
+  let userData = {};
+
+  before('Create test data', () => {
+    cy.createTempUser([
+      Permissions.listsAll.gui,
+      Permissions.uiUsersViewRequests.gui,
+      Permissions.uiOrdersCreate.gui,
+      Permissions.uiOrganizationsViewEditCreate.gui,
+      Permissions.uiUsersLoansViewRenewChangeDueDate.gui,
+      Permissions.inventoryAll.gui,
+    ]).then((userProperties) => {
+      userData = userProperties;
+      
+      cy.login(userData.username, userData.password, {
+        path: TopMenu.listsPath,
+        waiter: Lists.waitLoading,
+      });
+    });
+  });
+
+  after('Delete test data', () => {
+    cy.getAdminToken();
+    Users.deleteViaApi(userData.userId);
+  });
+
+  it('C411840 Inactive lists - Verify inactive list details page structure and functionality', 
+    { tags: ['criticalPath', 'lists'] }, 
+    () => {
+      // Navigate to inactive lists page
+      cy.visit('/lists?filters=status.Inactive&limit=100&offset=0');
+      Lists.waitLoading();
+
+      // Verify we're on the inactive lists page with inactive filter checked
+      Lists.verifyInactiveFilterIsChecked();
+      Lists.verifyListsPageDisplayed();
+
+      // Step 1: Click on any of the inactive lists
+      Lists.selectFirstInactiveList();
+      
+      // Verify list details page opens
+      Lists.verifyListDetailsPageOpened();
+
+      // Step 2: Check the structure of the lists details page
+      // Verify title is displayed
+      Lists.verifyListTitle();
+      
+      // Verify "X records found" is displayed under the title
+      Lists.verifyRecordsFoundText();
+      
+      // Verify X button at top-left
+      Lists.verifyCloseButtonExists();
+      
+      // Verify Actions dropdown at top-right
+      Lists.verifyActionsButtonExists();
+      
+      // Verify List information accordion
+      Lists.verifyListInformationAccordionExists();
+      
+      // Verify Query accordion
+      Lists.verifyQueryAccordionExists();
+
+      // Step 3: Click on "Actions" dropdown
+      Lists.openActionsDropdown();
+      
+      // Verify dropdown options are displayed
+      Lists.verifyActionsDropdownOptions();
+
+      // Step 4: Check the buttons status
+      // Verify inactive buttons (disabled)
+      Lists.verifyRefreshListButtonIsDisabled();
+      Lists.verifyExportVisibleColumnsButtonIsDisabled();
+      Lists.verifyExportAllColumnsButtonIsDisabled();
+      
+      // Verify active buttons (enabled)
+      Lists.verifyEditListButtonIsEnabled();
+      Lists.verifyDuplicateListButtonIsEnabled();
+      Lists.verifyDeleteListButtonIsEnabled();
+
+      // Close actions dropdown by clicking elsewhere
+      Lists.closeActionsDropdown();
+
+      // Step 5: Click on "List information" dropdown (collapse)
+      Lists.collapseListInformationAccordion();
+      
+      // Verify the accordion collapses
+      Lists.verifyListInformationAccordionCollapsed();
+
+      // Step 6: Click on "List information" dropdown again (expand)
+      Lists.expandListInformationAccordion();
+      
+      // Verify the accordion expands and contains required information
+      Lists.verifyListInformationAccordionExpanded();
+      Lists.verifyListInformationContent();
+
+      // Step 7: Click on "Query" dropdown (collapse)
+      Lists.collapseQueryAccordion();
+      
+      // Verify the accordion collapses
+      Lists.verifyQueryAccordionCollapsed();
+
+      // Step 8: Click on "Query" dropdown again (expand)
+      Lists.expandQueryAccordion();
+      
+      // Verify the accordion expands and shows query information
+      Lists.verifyQueryAccordionExpanded();
+      Lists.verifyQueryContent();
+
+      // Step 9: Click on "X" button
+      Lists.closeListDetailsPage();
+      
+      // Verify list details page closes and landing page opens
+      Lists.verifyListDetailsPageClosed();
+      Lists.verifyBackOnListsLandingPage();
+      
+      // Verify we're back on the lists landing page with inactive filter
+      Lists.verifyInactiveFilterIsChecked();
+      cy.url().should('include', 'lists?filters=status.Inactive');
+    }
+  );
+});

--- a/cypress/support/fragments/lists/lists.js
+++ b/cypress/support/fragments/lists/lists.js
@@ -1167,4 +1167,158 @@ export const Lists = {
   ...QueryBuilder,
   ...UI,
   ...API,
+
+  verifyListsPageDisplayed() {
+    cy.expect(Pane('Lists').exists());
+    cy.expect(HTML(including('records found')).exists());
+  },
+
+  verifyInactiveFilterIsChecked() {
+    cy.expect(Checkbox('Inactive').has({ checked: true }));
+  },
+
+  selectFirstInactiveList() {
+    cy.do(
+      MultiColumnListRow({ index: 0 })
+        .find(MultiColumnListCell({ columnIndex: 0 }))
+        .find(Link())
+        .click()
+    );
+  },
+
+  verifyListDetailsPageOpened() {
+    cy.expect(HTML(including('dialog')).exists());
+    cy.expect(HTML(including('records found')).exists());
+  },
+
+  verifyListTitle() {
+    cy.expect(HTML(including('heading')).exists());
+  },
+
+  verifyRecordsFoundText() {
+    cy.expect(HTML(including('records found')).exists());
+  },
+
+  verifyCloseButtonExists() {
+    cy.expect(Button({ ariaLabel: including('Close') }).exists());
+  },
+
+  verifyActionsButtonExists() {
+    cy.expect(Button('Actions').exists());
+  },
+
+  openActionsDropdown() {
+    cy.do(Button('Actions').click());
+  },
+
+  verifyActionsDropdownOptions() {
+    cy.expect([
+      HTML(including('Refresh list')).exists(),
+      HTML(including('Edit list')).exists(),
+      HTML(including('Duplicate list')).exists(),
+      HTML(including('Delete list')).exists(),
+      HTML(including('Export selected columns (CSV)')).exists(),
+      HTML(including('Export all columns (CSV)')).exists(),
+    ]);
+  },
+
+  verifyRefreshListButtonIsDisabled() {
+    cy.expect(HTML(including('Refresh list')).has({ disabled: true }));
+  },
+
+  verifyExportVisibleColumnsButtonIsDisabled() {
+    cy.expect(HTML(including('Export visible columns (CSV)')).has({ disabled: true }));
+  },
+
+  verifyExportAllColumnsButtonIsDisabled() {
+    cy.expect(HTML(including('Export all columns (CSV)')).has({ disabled: true }));
+  },
+
+  verifyEditListButtonIsEnabled() {
+    cy.expect(HTML(including('Edit list')).has({ disabled: false }));
+  },
+
+  verifyDuplicateListButtonIsEnabled() {
+    cy.expect(HTML(including('Duplicate list')).has({ disabled: false }));
+  },
+
+  verifyDeleteListButtonIsEnabled() {
+    cy.expect(HTML(including('Delete list')).has({ disabled: false }));
+  },
+
+  closeActionsDropdown() {
+    cy.do(HTML().click());
+  },
+
+  verifyListInformationAccordionExists() {
+    cy.expect(this.listInformationAccordion.exists());
+  },
+
+  verifyQueryAccordionExists() {
+    cy.expect(this.queryAccordion.exists());
+  },
+
+  collapseListInformationAccordion() {
+    cy.do(this.listInformationAccordion.clickHeader());
+  },
+
+  expandListInformationAccordion() {
+    cy.do(this.listInformationAccordion.clickHeader());
+  },
+
+  verifyListInformationAccordionCollapsed() {
+    cy.expect(this.listInformationAccordion.has({ open: false }));
+  },
+
+  verifyListInformationAccordionExpanded() {
+    cy.expect(this.listInformationAccordion.has({ open: true }));
+  },
+
+  verifyListInformationContent() {
+    cy.expect([
+      this.listInformationAccordion.find(HTML(including('Record last updated'))).exists(),
+      this.listInformationAccordion.find(HTML(including('Source'))).exists(),
+      this.listInformationAccordion.find(HTML(including('Record created'))).exists(),
+      this.listInformationAccordion.find(HTML(including('Description'))).exists(),
+      this.listInformationAccordion.find(HTML(including('Visibility'))).exists(),
+      this.listInformationAccordion.find(HTML(including('Status'))).exists(),
+      this.listInformationAccordion.find(HTML(including('Inactive'))).exists(),
+      this.listInformationAccordion.find(HTML(including('System'))).exists(),
+    ]);
+  },
+
+  collapseQueryAccordion() {
+    cy.do(this.queryAccordion.clickHeader());
+  },
+
+  expandQueryAccordion() {
+    cy.do(this.queryAccordion.clickHeader());
+  },
+
+  verifyQueryAccordionCollapsed() {
+    cy.expect(this.queryAccordion.has({ open: false }));
+  },
+
+  verifyQueryAccordionExpanded() {
+    cy.expect(this.queryAccordion.has({ open: true }));
+  },
+
+  verifyQueryContent() {
+    cy.expect([
+      this.queryAccordion.find(HTML(including('0 records found'))).exists(),
+      this.queryAccordion.find(HTML(including('The list contains no items'))).exists(),
+    ]);
+  },
+
+  closeListDetailsPage() {
+    cy.do(Button({ ariaLabel: including('Close') }).click());
+  },
+
+  verifyListDetailsPageClosed() {
+    cy.expect(HTML(including('dialog')).absent());
+  },
+
+  verifyBackOnListsLandingPage() {
+    cy.expect(Pane('Lists').exists());
+  },
 };


### PR DESCRIPTION
This PR implements automated test coverage for TestRail case **C411840 "Inactive lists"** which verifies the functionality of viewing and interacting with inactive lists in the Lists module.

**Test Coverage:**
- ✅ Opening inactive list details page
- ✅ Verifying page structure (title, record count, X button, Actions dropdown)
- ✅ Testing Actions dropdown options (Refresh, Edit, Duplicate, Delete, Export)
- ✅ Checking button states (inactive vs active)
- ✅ Testing accordion behavior (List information, Query sections)
- ✅ Verifying navigation back to landing page

**Key Features:**
- Follows FOLIO Stripes TAF best practices
- Uses existing page object patterns
- Implements proper test isolation and cleanup
- Includes comprehensive assertions for all UI elements
- Maintains consistency with existing test structure

**Files Modified:**
- `cypress/e2e/lists/inactive-lists-details-page.cy.js` (new test file)
- `cypress/support/fragments/lists/lists.js` (extended with new methods)

**Test Tags:** `criticalPath`, `lists`

**Related TestRail:** C411840 - Inactive lists  
**Related JIRA:** UILISTS-54

The PR is ready for review and testing.