### PR TITLE
FAT-21830: C387438 add log to check if user is deleted

### DIFF
--- a/cypress/e2e/staff-slips/metadata-accordion-unknown-user-deleted.cy.js
+++ b/cypress/e2e/staff-slips/metadata-accordion-unknown-user-deleted.cy.js
@@ -55,7 +55,11 @@ describe('Staff slips', () => {
         });
 
         cy.getAdminToken();
-        Users.deleteViaApi(userData.userId);
+        Users.deleteViaApi(userData.userId).then((status) => {
+          if (status !== 204) {
+            throw new Error(`User with id=${userData.userId} was not deleted`);
+          }
+        });
 
         cy.createTempUser(
           [Permissions.uiCirculationCreateEditRemoveStaffSlips.gui, Permissions.uiUsersView.gui],


### PR DESCRIPTION
It looks like the user is not being deleted, since "Source: Unknown user" is not displayed in the [screenshot](https://report-portal.ci.folio.org/ui/#cypress-nightly/launches/all/7960/2421049/2421068/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dti001%26filter.cnt.name%3Dvolaris%26page.page%3D1). Let's check the status and throw an error if the user hasn't been deleted to better understand the cause of the test instability. The test fails in the env but not locally.