### PR TITLE
FAT-21830-C163922-fix

### DIFF
--- a/cypress/support/fragments/settings/tenant/locations/createLocations.js
+++ b/cypress/support/fragments/settings/tenant/locations/createLocations.js
@@ -1,4 +1,4 @@
-import { Button, Select, TextField } from '../../../../../../interactors';
+import { Button, Select, TextField, including } from '../../../../../../interactors';
 import getRandomPostfix from '../../../../utils/stringTools';
 
 export default {
@@ -14,6 +14,8 @@ export default {
   selectRemoteStorage(value = 'RS1') {
     // the asterisk sometimes doesn't appear immediately, so we use `exists` to wait for it
     cy.expect(Select('Remote storage*').exists());
+    // Check if the option is not disabled
+    cy.expect(Select('Remote storage*').has({ optionsText: including(value) }));
     cy.do(Select('Remote storage*').choose(value));
   },
   selectServicePoint(value = 'Online') {


### PR DESCRIPTION
The C163922 sometimes fails because the new location is saved without the selected remote storage. Remote storage field waits for a GET request and only then contains options. Wait for the option to be available, select it and only then do the rest.
Fixes https://report-portal.ci.folio.org/ui/#cypress-nightly/launches/all/7960/2426043/2426051/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dti001%26filter.cnt.name%3Dvolaris%26page.page%3D1