### PR TITLE
Split ACQ-related constants to separate files based on domain

### DIFF
--- a/cypress/e2e/orders/routing-lists-accordion-is-expanded-when-po-line-has-related-routing-list-and-order-format-physical.cy.js
+++ b/cypress/e2e/orders/routing-lists-accordion-is-expanded-when-po-line-has-related-routing-list-and-order-format-physical.cy.js
@@ -22,7 +22,7 @@ import {
   ORDER_STATUSES,
   ORDER_TYPES,
   POL_CREATE_INVENTORY_SETTINGS,
-  RECEIVING_TITILE_ACCORDION_NAMES,
+  RECEIVING_TITLE_ACCORDION_NAMES,
 } from '../../support/constants';
 
 describe('Orders', () => {
@@ -217,9 +217,9 @@ describe('Orders', () => {
       Receiving.verifyRoutingListWarning();
       ReceivingDetails.checkRoutingListSectionExpanded();
       ReceivingDetails.checkAccordionPosition({
-        previousAccordionLabel: RECEIVING_TITILE_ACCORDION_NAMES.RECEIVED,
-        targetAccordionLabel: RECEIVING_TITILE_ACCORDION_NAMES.ROUTING_LISTS,
-        nextAccordionLabel: RECEIVING_TITILE_ACCORDION_NAMES.UNRECEIVABLE,
+        previousAccordionLabel: RECEIVING_TITLE_ACCORDION_NAMES.RECEIVED,
+        targetAccordionLabel: RECEIVING_TITLE_ACCORDION_NAMES.ROUTING_LISTS,
+        nextAccordionLabel: RECEIVING_TITLE_ACCORDION_NAMES.UNRECEIVABLE,
       });
       ReceivingDetails.checkRoutingListTableContent([
         {

--- a/cypress/support/constants/consortia/index.js
+++ b/cypress/support/constants/consortia/index.js
@@ -1,0 +1,13 @@
+export const CONSORTIA_SYSTEM_USER = 'System, System user - mod-consortia-keycloak';
+
+export const PUBLISH_COORDINATOR_STATUSES = {
+  COMPLETE: 'COMPLETE',
+  ERROR: 'ERROR',
+  IN_PROGRESS: 'IN_PROGRESS',
+};
+
+export const PUBLISH_COORDINATOR_SHARE_DETAILS_KEYS = {
+  CREATE: 'createSettingsPCId',
+  DELETE: 'pcId',
+  UPDATE: 'updateSettingsPCId',
+};

--- a/cypress/support/constants/constants.js
+++ b/cypress/support/constants/constants.js
@@ -96,14 +96,6 @@ export const ITEM_STATUS_NAMES = {
   ORDER_CLOSED: 'Order closed',
 };
 
-export const BUDGET_STATUSES = {
-  ACTIVE: 'Active',
-  CLOZED: 'Clozed',
-  FROZEN: 'Frozed',
-  INACTIVE: 'Inactive',
-  PLANNED: 'Planned',
-};
-
 export const CY_ENV = {
   CIRCULATION_RULES: 'circulationRules',
   DIKU_LOGIN: 'diku_login',
@@ -173,20 +165,6 @@ export const BATCH_GROUP = {
   AMHERST: '"Amherst (AC)"',
 };
 
-export const INVOICE_STATUSES = {
-  OPEN: 'Open',
-  REVIEWED: 'Reviewed',
-  APPROVED: 'Approved',
-  CANCELLED: 'Cancelled',
-  PAID: 'Paid',
-};
-
-export const ORDER_STATUSES = {
-  OPEN: 'Open',
-  PENDING: 'Pending',
-  CLOSED: 'Closed',
-};
-
 export const RECORD_STATUSES = {
   CREATED: 'Created',
   UPDATED: 'Updated',
@@ -194,106 +172,6 @@ export const RECORD_STATUSES = {
   DASH: 'No value set-',
   BLANK: 'No value set',
   ERROR: 'Error',
-};
-
-export const ORDER_TYPES = {
-  ONE_TIME: 'One-time',
-  ONGOING: 'Ongoing',
-};
-
-export const ORDER_FORMAT_NAMES = {
-  ELECTRONIC_RESOURCE: 'Electronic resource',
-  ELECTRONIC_RESOURCE_Check: 'Electronic Resource', // Deprecated, need to be removed after all tests will be updated
-  PE_MIX: 'P/E mix',
-  PE_MIX_Check: 'P/E Mix',
-  OTHER: 'Other',
-  PHYSICAL_RESOURCE: 'Physical resource',
-  PHYSICAL_RESOURCE_Check: 'Physical Resource', // Deprecated, need to be removed after all tests will be updated
-};
-
-export const ORDER_PAYMENT_STATUS = {
-  PENDING: 'Pending',
-  PAYMENT_NOT_REQUIRED: 'Payment not required',
-};
-
-export const ORDER_LINE_PAYMENT_STATUS = {
-  AWAITING_PAYMENT: 'Awaiting payment',
-  CANCELLED: 'Cancelled',
-  FULLY_PAID: 'Fully paid',
-  ONGOING: 'Ongoing',
-  PARTIALLY_PAID: 'Partially paid',
-  PAYMENT_NOT_REQUIRED: 'Payment not required',
-};
-
-export const ORDER_FORMAT_NAMES_IN_PROFILE = {
-  ELECTRONIC_RESOURCE: 'Electronic Resource',
-  PE_MIX: 'P/E Mix',
-  OTHER: 'Other',
-  PHYSICAL_RESOURCE: 'Physical Resource',
-};
-
-export const ORDER_SYSTEM_CLOSING_REASONS = {
-  CANCELLED: 'Cancelled',
-  CEASED: 'Ceased',
-  COMPLETE: 'Complete',
-  TRANSFERRED_TO_ANOTHER_PUBLISHER: 'Transferred to another publisher',
-  MERGED_WITH_ANOTHER_TITLE: 'Merged with another title',
-  SPLIT_INTO_OTHER_TITLES: 'Split into other titles',
-  LACK_OF_FUNDS: 'Lack of funds',
-  LACK_OF_USE: 'Lack of use',
-  DUPLICATION: 'Duplication',
-  UNRESPONSIVE_VENDOR: 'Unresponsive vendor',
-  LICENSING_TERMS: 'Licensing terms (unacceptable)',
-  LOW_QUALITY: 'Low quality',
-  UNPREFERRED_FORMAT: 'Unpreferred format',
-  ERROR: 'Error',
-  TITLE_WONT_BE_PUBLISHED_THIS_YEAR: "Title won't be published this year",
-  TITLE_WONT_BE_PUBLISHED: "Title won't be published",
-  TITLE_OUT_OF_PRINT: 'Title is out of print',
-  TITLE_RECEIVED_AS_GIFT: 'Title received as a gift',
-};
-
-export const ACQUISITION_METHOD_NAMES_IN_PROFILE = {
-  APPROVAL_PLAN: 'Approval plan',
-  PURCHASE: 'Purchase',
-  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase at vendor system',
-  OTHER: 'Other',
-};
-
-export const RECEIPT_STATUS_SELECTED = {
-  PENDING: 'Pending',
-  RECEIPT_NOT_REQUIRED: 'Receipt not required',
-};
-
-export const RECEIPT_STATUS_VIEW = {
-  AWAITING_RECEIPT: 'Awaiting receipt',
-  CANCELLED: 'Cancelled',
-  PENDING: 'Pending',
-  FULLY_RECEIVED: 'Fully received',
-  ONGOING: 'Ongoing',
-  PARTIALLY_RECEIVED: 'Partially received',
-  RECEIPT_NOT_REQUIRED: 'Receipt not required',
-};
-
-export const RECEIVING_WORKFLOW_NAMES = {
-  SYNCHRONIZED_ORDER_AND_RECEIPT_QUANTITY: 'Synchronized order and receipt quantity',
-  INDEPENDENT_ORDER_AND_RECEIPT_QUANTITY: 'Independent order and receipt quantity',
-};
-
-export const ACQUISITION_METHOD_NAMES = {
-  APPROVAL_PLAN: 'Approval plan',
-  DDA: 'Demand driven acquisitions (DDA)',
-  DEPOSITORY: 'Depository',
-  EBA: 'Evidence based acquisitions (EBA)',
-  EXCHANGE: 'Exchange',
-  FREE: 'Free',
-  GIFT: 'Gift',
-  INTERNAL_TRANSFER: 'Internal transfer',
-  MEMBERSHIP: 'Membership',
-  OTHER: 'Other',
-  PURCHASE: 'Purchase',
-  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase At Vendor System',
-  TECHNICAL: 'Technical',
 };
 
 export const INSTITUTION_NAMES = {
@@ -419,22 +297,6 @@ export const NOTE_TYPES = {
   GENERAL: 'General note',
   NOTE_1516: 'Note type 1516',
   NOTE_1654: 'Note-type-1654',
-};
-
-export const ACQUISITION_METHOD_NAMES_IN_MAPPING_PROFILES = {
-  APPROVAL_PLAN: 'Approval Plan',
-  DDA: 'Demand Driven Acquisitions (DDA)',
-  DEPOSITORY: 'Depository',
-  EBA: 'Evidence Based Acquisitions (EBA)',
-  EXCHANGE: 'Exchange',
-  FREE: 'Free',
-  GIFT: 'Gift',
-  INTERNAL_TRANSFER: 'Internal transfer',
-  MEMBERSHIP: 'Membership',
-  OTHER: 'Other',
-  PURCHASE: 'Purchase',
-  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase At Vendor System',
-  TECHNICAL: 'Technical',
 };
 
 export const REMOTE_STORAGE_PROVIDER_NAMES = {
@@ -1847,75 +1709,10 @@ export const EHOLDINGS_KB_SETTINGS_TABS = {
   USAGE_CONSOLIDATION: 'Usage consolidation',
 };
 
-export const CONSORTIA_SYSTEM_USER = 'System, System user - mod-consortia-keycloak';
-
-export const PUBLISH_COORDINATOR_STATUSES = {
-  COMPLETE: 'COMPLETE',
-  ERROR: 'ERROR',
-  IN_PROGRESS: 'IN_PROGRESS',
-};
-
-export const PUBLISH_COORDINATOR_SHARE_DETAILS_KEYS = {
-  CREATE: 'createSettingsPCId',
-  DELETE: 'pcId',
-  UPDATE: 'updateSettingsPCId',
-};
-
 export const DELETE_HOLDINGS_ACTIONS = {
   CANCEL: 'Cancel',
   KEEP_HOLDINGS: 'Keep Holdings',
   DELETE_HOLDINGS: 'Delete Holdings',
-};
-
-export const TRANSACTION_TYPES = {
-  ALLOCATION: 'Allocation',
-  CREDIT: 'Credit',
-  ENCUMBRANCE: 'Encumbrance',
-  PAYMENT: 'Payment',
-  PENDING_PAYMENT: 'Pending payment',
-  ROLLOVER_TRANSFER: 'Rollover transfer',
-  TRANSFER: 'Transfer',
-};
-
-export const POL_CREATE_INVENTORY_SETTINGS = {
-  INSTANCE: 'Instance',
-  INSTANCE_HOLDING: 'Instance, Holding',
-  INSTANCE_HOLDING_ITEM: 'Instance, Holding, Item',
-  NONE: 'None',
-};
-
-export const ORGANIZATION_STATUSES = {
-  ACTIVE: 'Active',
-  INACTIVE: 'Inactive',
-  PENDING: 'Pending',
-};
-
-export const INVOICE_POL_PAYMENT_STATUSES = {
-  AWAITING_PAYMENT: 'Awaiting Payment',
-  CANCELLED: 'Cancelled',
-  FULLY_PAID: 'Fully Paid',
-  NO_CHANGE: 'No Change',
-  PARTIALLY_PAID: 'Partially Paid',
-};
-
-export const POLINE_DETAILS_FIELDS = {
-  ORDER_FORMAT: 'Order format',
-  RECEIPT_STATUS: 'Receipt status',
-  PAYMENT_STATUS: 'Payment status',
-  HOLDING_NAME: 'Holding',
-  LOCATION_NAME: 'Name (code)',
-  PHYSICAL_UNIT_PRICE: 'Physical unit price',
-  QUANTITY_PHYSICAL: 'Quantity physical',
-  ELECTRONIC_UNIT_PRICE: 'Electronic unit price',
-  QUANTITY_ELECTRONIC: 'Quantity electronic',
-  CREATE_INVENTORY: 'Create inventory',
-};
-
-export const POL_CREATE_INVENTORY_SETTINGS_VIEW = {
-  INSTANCE: 'Instance',
-  INSTANCE_HOLDING: 'Instance, holdings',
-  INSTANCE_HOLDING_ITEM: 'Instance, holdings, item',
-  NONE: 'None',
 };
 
 export const USER_TYPES = {
@@ -1923,164 +1720,4 @@ export const USER_TYPES = {
   PATRON: 'Patron',
   SYSTEM: 'System',
   SHADOW: 'Shadow',
-};
-
-export const ORDER_LINE_ACCORDION_NAMES = {
-  ITEM_DETAILS: 'Item details',
-  PURCHASE_ORDER_LINE: 'Purchase order line',
-  DONOR_INFORMATION: 'Donor information',
-  VENDOR: 'Vendor',
-  COST_DETAILS: 'Cost details',
-  FUND_DISTRIBUTION: 'Fund distribution',
-  LOCATION: 'Location',
-  PHYSICAL_RESOURCE_DETAILS: 'Physical resource details',
-  E_RESOURCES_DETAILS: 'E-resources details',
-  ROUTING_LISTS: 'Routing lists',
-  NOTES: 'Notes',
-  RELATED_INVOICE_LINES: 'Related invoice lines',
-  LINKED_INSTANCE: 'Linked instance',
-  CUSTOM_FIELDS: 'Custom fields',
-};
-
-export const RECEIVING_TITILE_ACCORDION_NAMES = {
-  TITLE_INFORMATION: 'Title information',
-  POL_DETAILS: 'POL details',
-  EXPECTED: 'Expected',
-  RECEIVED: 'Received',
-  ROUTING_LISTS: 'Routing lists',
-  UNRECEIVABLE: 'Unreceivable',
-  BOUND_ITEMS: 'Bound items',
-};
-
-export const FUNDING_INFORMATION_NAMES = {
-  INITIAL_ALLOCATION: 'Initial allocation',
-  TOTAL_ALLOCATED: 'Total allocated',
-  TOTAL_FUNDING: 'Total funding',
-};
-
-export const FINANCIAL_ACTIVITY_OVERRAGES = {
-  ENCUMBERED: 'Encumbered',
-  AWAITING_PAYMENT: 'Awaiting payment',
-  EXPENDED: 'Expended',
-  CREDITED: 'Credited',
-  UNAVAILABLE: 'Unavailable',
-  OVER_ENCUMBRANCE: 'Over encumbrance',
-  OVER_EXPENDED: 'Over expended',
-  AVAILABLE_BALANCE: 'Available balance',
-};
-
-export const TRANSACTION_DETAIL_FIELDS = {
-  FISCAL_YEAR: 'Fiscal year',
-  TRANSACTION_DATE: 'Transaction date',
-  AMOUNT: 'Amount',
-  SOURCE: 'Source',
-  TYPE: 'Type',
-  FROM: 'From',
-  TO: 'To',
-  EXPENSE_CLASS: 'Expense class',
-  TAGS: 'Tags',
-  INITIAL_ENCUMBRANCE: 'Initial encumbrance',
-  AWAITING_PAYMENT: 'Awaiting payment',
-  EXPENDED: 'Expended',
-  STATUS: 'Status',
-  DESCRIPTION: 'Description',
-};
-
-export const ENCUMBRANCE_STATUSES = {
-  RELEASED: 'Released',
-  UNRELEASED: 'Unreleased',
-};
-
-export const INVOICE_VIEW_FIELDS = {
-  FISCAL_YEAR: 'Fiscal year',
-  INVOICE_STATUS: 'Status',
-  SUB_TOTAL: 'Sub-total',
-  VENDOR_NAME: 'Vendor name',
-  VOUCHER_STATUS: 'Status',
-};
-
-export const INVOICE_LINE_VIEW_FIELDS = {
-  STATUS: 'Status',
-  SUB_TOTAL: 'Sub-total',
-};
-
-export const FUND_DISTRIBUTION_TYPES = {
-  AMOUNT: 'amount',
-  PERCENTAGE: 'percentage',
-};
-export const LEDGER_VIEW_FIELDS = {
-  NAME: 'Name',
-  CODE: 'Code',
-  FISCAL_YEAR: 'Fiscal year',
-  STATUS: 'Status',
-};
-
-export const LEDGER_STATUSES = {
-  ACTIVE: 'Active',
-  FROZEN: 'Frozen',
-  INACTIVE: 'Inactive',
-};
-
-export const EXPORT_FUND_FIELDS = {
-  FUND_NAME: 'Name (Fund)',
-  FUND_CODE: 'Code (Fund)',
-  FUND_STATUS: 'Status (Fund)',
-  FUND_TYPE: 'Type',
-  FUND_GROUPS: 'Group (Code)',
-  ACQ_UNITS: 'Acquisition unit',
-  TRANSFER_FROM: 'Transfer from',
-  TRANSFER_TO: 'Transfer to',
-  EXTERNAL_ACCOUNT_NO: 'External account number',
-  FUND_DESCRIPTION: 'Description',
-};
-
-export const EXPORT_BUDGET_FIELDS = {
-  BUDGET_NAME: 'Name (Budget)',
-  BUDGET_STATUS: 'Status (Budget)',
-  ALLOWABLE_ENCUMBRANCE: 'Allowable encumbrance',
-  ALLOWABLE_EXPENDITURE: 'Allowable expenditure',
-  CREATED_DATE: 'Date created (Budget)',
-  INITIAL_ALLOCATION: 'Initial allocation',
-  ALLOCATED_INCREASE: 'Increase',
-  ALLOCATED_DECREASE: 'Decrease',
-  TOTAL_ALLOCATED: 'Total allocation',
-  TRANSFERS: 'Transfers',
-  TOTAL_FUNDING: 'Total Funding',
-  BUDGET_ENCUMBERED: 'Encumbered (Budget)',
-  AWAITING_PAYMENT: 'Awaiting payment (Budget)',
-  EXPENDED: 'Expended (Budget)',
-  CREDITED: 'Credited (Budget)',
-  UNAVAILABLE: 'Unavailable',
-  OVER_ENCUMBERED: 'Over encumbered',
-  OVER_EXPENDED: 'Over expended',
-  CASH_BALANCE: 'Cash balance',
-  AVAILABLE: 'Available',
-};
-
-export const EXPORT_EXPENSE_CLASS_FIELDS = {
-  EXPENSE_CLASS_NAME: 'Name (Exp Class)',
-  EXPENSE_CLASS_CODE: 'Code (Exp Class)',
-  EXPENSE_CLASS_STATUS: 'Status (Exp Class)',
-  EXPENSE_CLASS_ENCUMBERED: 'Encumbered (Exp Class)',
-  EXPENSE_CLASS_AWAITING_PAYMENT: 'Awaiting payment (Exp Class)',
-  EXPENSE_CLASS_EXPENDED: 'Expended (Exp Class)',
-  EXPENSE_CLASS_CREDITED: 'Credited (Exp Class)',
-  PERCENTAGE_OF_TOTAL_EXPENDED: 'Percentage of total expended',
-};
-
-export const LEDGER_ROLLOVER_TYPES = {
-  COMMIT: 'Commit',
-  PREVIEW: 'Preview',
-  ROLLBACK: 'Rollback',
-};
-
-export const LEDGER_ROLLOVER_SOURCE_LABELS = {
-  [LEDGER_ROLLOVER_TYPES.COMMIT]: 'Rollover',
-  [LEDGER_ROLLOVER_TYPES.PREVIEW]: 'Rollover test',
-};
-
-export const LEDGER_ROLLOVER_STATUS_LABELS = {
-  IN_PROCESS: 'In process',
-  NOT_STARTED: 'Not started',
-  SUCCESS: 'Successful',
 };

--- a/cypress/support/constants/finance/budget.js
+++ b/cypress/support/constants/finance/budget.js
@@ -1,0 +1,30 @@
+export const BUDGET_STATUSES = {
+  ACTIVE: 'Active',
+  CLOSED: 'Closed',
+  FROZEN: 'Frozen',
+  INACTIVE: 'Inactive',
+  PLANNED: 'Planned',
+};
+
+export const EXPORT_BUDGET_FIELDS = {
+  BUDGET_NAME: 'Name (Budget)',
+  BUDGET_STATUS: 'Status (Budget)',
+  ALLOWABLE_ENCUMBRANCE: 'Allowable encumbrance',
+  ALLOWABLE_EXPENDITURE: 'Allowable expenditure',
+  CREATED_DATE: 'Date created (Budget)',
+  INITIAL_ALLOCATION: 'Initial allocation',
+  ALLOCATED_INCREASE: 'Increase',
+  ALLOCATED_DECREASE: 'Decrease',
+  TOTAL_ALLOCATED: 'Total allocation',
+  TRANSFERS: 'Transfers',
+  TOTAL_FUNDING: 'Total Funding',
+  BUDGET_ENCUMBERED: 'Encumbered (Budget)',
+  AWAITING_PAYMENT: 'Awaiting payment (Budget)',
+  EXPENDED: 'Expended (Budget)',
+  CREDITED: 'Credited (Budget)',
+  UNAVAILABLE: 'Unavailable',
+  OVER_ENCUMBERED: 'Over encumbered',
+  OVER_EXPENDED: 'Over expended',
+  CASH_BALANCE: 'Cash balance',
+  AVAILABLE: 'Available',
+};

--- a/cypress/support/constants/finance/expense-class.js
+++ b/cypress/support/constants/finance/expense-class.js
@@ -1,0 +1,10 @@
+export const EXPORT_EXPENSE_CLASS_FIELDS = {
+  EXPENSE_CLASS_NAME: 'Name (Exp Class)',
+  EXPENSE_CLASS_CODE: 'Code (Exp Class)',
+  EXPENSE_CLASS_STATUS: 'Status (Exp Class)',
+  EXPENSE_CLASS_ENCUMBERED: 'Encumbered (Exp Class)',
+  EXPENSE_CLASS_AWAITING_PAYMENT: 'Awaiting payment (Exp Class)',
+  EXPENSE_CLASS_EXPENDED: 'Expended (Exp Class)',
+  EXPENSE_CLASS_CREDITED: 'Credited (Exp Class)',
+  PERCENTAGE_OF_TOTAL_EXPENDED: 'Percentage of total expended',
+};

--- a/cypress/support/constants/finance/fiscal-year.js
+++ b/cypress/support/constants/finance/fiscal-year.js
@@ -1,0 +1,16 @@
+export const FUNDING_INFORMATION_NAMES = {
+  INITIAL_ALLOCATION: 'Initial allocation',
+  TOTAL_ALLOCATED: 'Total allocated',
+  TOTAL_FUNDING: 'Total funding',
+};
+
+export const FINANCIAL_ACTIVITY_OVERRAGES = {
+  ENCUMBERED: 'Encumbered',
+  AWAITING_PAYMENT: 'Awaiting payment',
+  EXPENDED: 'Expended',
+  CREDITED: 'Credited',
+  UNAVAILABLE: 'Unavailable',
+  OVER_ENCUMBRANCE: 'Over encumbrance',
+  OVER_EXPENDED: 'Over expended',
+  AVAILABLE_BALANCE: 'Available balance',
+};

--- a/cypress/support/constants/finance/fund.js
+++ b/cypress/support/constants/finance/fund.js
@@ -1,0 +1,17 @@
+export const FUND_DISTRIBUTION_TYPES = {
+  AMOUNT: 'amount',
+  PERCENTAGE: 'percentage',
+};
+
+export const EXPORT_FUND_FIELDS = {
+  FUND_NAME: 'Name (Fund)',
+  FUND_CODE: 'Code (Fund)',
+  FUND_STATUS: 'Status (Fund)',
+  FUND_TYPE: 'Type',
+  FUND_GROUPS: 'Group (Code)',
+  ACQ_UNITS: 'Acquisition unit',
+  TRANSFER_FROM: 'Transfer from',
+  TRANSFER_TO: 'Transfer to',
+  EXTERNAL_ACCOUNT_NO: 'External account number',
+  FUND_DESCRIPTION: 'Description',
+};

--- a/cypress/support/constants/finance/index.js
+++ b/cypress/support/constants/finance/index.js
@@ -1,0 +1,7 @@
+export * from './budget';
+export * from './expense-class';
+export * from './fiscal-year';
+export * from './fund';
+export * from './ledger';
+export * from './rollover';
+export * from './transaction';

--- a/cypress/support/constants/finance/ledger.js
+++ b/cypress/support/constants/finance/ledger.js
@@ -1,0 +1,12 @@
+export const LEDGER_VIEW_FIELDS = {
+  NAME: 'Name',
+  CODE: 'Code',
+  FISCAL_YEAR: 'Fiscal year',
+  STATUS: 'Status',
+};
+
+export const LEDGER_STATUSES = {
+  ACTIVE: 'Active',
+  FROZEN: 'Frozen',
+  INACTIVE: 'Inactive',
+};

--- a/cypress/support/constants/finance/rollover.js
+++ b/cypress/support/constants/finance/rollover.js
@@ -1,0 +1,22 @@
+export const ROLLOVER_BUDGET_VALUE = {
+  NONE: 'None',
+  AVAILABLE: 'Available',
+  CASH_BALANCE: 'CashBalance',
+};
+
+export const LEDGER_ROLLOVER_TYPES = {
+  COMMIT: 'Commit',
+  PREVIEW: 'Preview',
+  ROLLBACK: 'Rollback',
+};
+
+export const LEDGER_ROLLOVER_SOURCE_LABELS = {
+  [LEDGER_ROLLOVER_TYPES.COMMIT]: 'Rollover',
+  [LEDGER_ROLLOVER_TYPES.PREVIEW]: 'Rollover test',
+};
+
+export const LEDGER_ROLLOVER_STATUS_LABELS = {
+  IN_PROCESS: 'In process',
+  NOT_STARTED: 'Not started',
+  SUCCESS: 'Successful',
+};

--- a/cypress/support/constants/finance/transaction.js
+++ b/cypress/support/constants/finance/transaction.js
@@ -1,0 +1,31 @@
+export const ENCUMBRANCE_STATUSES = {
+  RELEASED: 'Released',
+  UNRELEASED: 'Unreleased',
+};
+
+export const TRANSACTION_DETAIL_FIELDS = {
+  FISCAL_YEAR: 'Fiscal year',
+  TRANSACTION_DATE: 'Transaction date',
+  AMOUNT: 'Amount',
+  SOURCE: 'Source',
+  TYPE: 'Type',
+  FROM: 'From',
+  TO: 'To',
+  EXPENSE_CLASS: 'Expense class',
+  TAGS: 'Tags',
+  INITIAL_ENCUMBRANCE: 'Initial encumbrance',
+  AWAITING_PAYMENT: 'Awaiting payment',
+  EXPENDED: 'Expended',
+  STATUS: 'Status',
+  DESCRIPTION: 'Description',
+};
+
+export const TRANSACTION_TYPES = {
+  ALLOCATION: 'Allocation',
+  CREDIT: 'Credit',
+  ENCUMBRANCE: 'Encumbrance',
+  PAYMENT: 'Payment',
+  PENDING_PAYMENT: 'Pending payment',
+  ROLLOVER_TRANSFER: 'Rollover transfer',
+  TRANSFER: 'Transfer',
+};

--- a/cypress/support/constants/index.js
+++ b/cypress/support/constants/index.js
@@ -1,0 +1,8 @@
+/* TODO: reduce code duplications across constants */
+export * from './consortia';
+export * from './constants';
+export * from './finance';
+export * from './invoices';
+export * from './orders';
+export * from './organizations';
+export * from './receiving';

--- a/cypress/support/constants/invoices/index.js
+++ b/cypress/support/constants/invoices/index.js
@@ -1,0 +1,2 @@
+export * from './invoice';
+export * from './invoice-line';

--- a/cypress/support/constants/invoices/invoice-line.js
+++ b/cypress/support/constants/invoices/invoice-line.js
@@ -1,0 +1,4 @@
+export const INVOICE_LINE_VIEW_FIELDS = {
+  STATUS: 'Status',
+  SUB_TOTAL: 'Sub-total',
+};

--- a/cypress/support/constants/invoices/invoice.js
+++ b/cypress/support/constants/invoices/invoice.js
@@ -1,0 +1,23 @@
+export const INVOICE_STATUSES = {
+  OPEN: 'Open',
+  REVIEWED: 'Reviewed',
+  APPROVED: 'Approved',
+  CANCELLED: 'Cancelled',
+  PAID: 'Paid',
+};
+
+export const INVOICE_POL_PAYMENT_STATUSES = {
+  AWAITING_PAYMENT: 'Awaiting Payment',
+  CANCELLED: 'Cancelled',
+  FULLY_PAID: 'Fully Paid',
+  NO_CHANGE: 'No Change',
+  PARTIALLY_PAID: 'Partially Paid',
+};
+
+export const INVOICE_VIEW_FIELDS = {
+  FISCAL_YEAR: 'Fiscal year',
+  INVOICE_STATUS: 'Status',
+  SUB_TOTAL: 'Sub-total',
+  VENDOR_NAME: 'Vendor name',
+  VOUCHER_STATUS: 'Status',
+};

--- a/cypress/support/constants/orders/index.js
+++ b/cypress/support/constants/orders/index.js
@@ -1,0 +1,2 @@
+export * from './order';
+export * from './order-line';

--- a/cypress/support/constants/orders/order-line.js
+++ b/cypress/support/constants/orders/order-line.js
@@ -1,0 +1,133 @@
+export const ORDER_LINE_ACCORDION_NAMES = {
+  ITEM_DETAILS: 'Item details',
+  PURCHASE_ORDER_LINE: 'Purchase order line',
+  DONOR_INFORMATION: 'Donor information',
+  VENDOR: 'Vendor',
+  COST_DETAILS: 'Cost details',
+  FUND_DISTRIBUTION: 'Fund distribution',
+  LOCATION: 'Location',
+  PHYSICAL_RESOURCE_DETAILS: 'Physical resource details',
+  E_RESOURCES_DETAILS: 'E-resources details',
+  ROUTING_LISTS: 'Routing lists',
+  NOTES: 'Notes',
+  RELATED_INVOICE_LINES: 'Related invoice lines',
+  LINKED_INSTANCE: 'Linked instance',
+  CUSTOM_FIELDS: 'Custom fields',
+};
+
+export const ORDER_LINE_PAYMENT_STATUS = {
+  AWAITING_PAYMENT: 'Awaiting payment',
+  CANCELLED: 'Cancelled',
+  FULLY_PAID: 'Fully paid',
+  ONGOING: 'Ongoing',
+  PARTIALLY_PAID: 'Partially paid',
+  PAYMENT_NOT_REQUIRED: 'Payment not required',
+};
+
+export const ORDER_FORMAT_NAMES_IN_PROFILE = {
+  ELECTRONIC_RESOURCE: 'Electronic Resource',
+  PE_MIX: 'P/E Mix',
+  OTHER: 'Other',
+  PHYSICAL_RESOURCE: 'Physical Resource',
+};
+
+export const ORDER_FORMAT_NAMES = {
+  ELECTRONIC_RESOURCE: 'Electronic resource',
+  ELECTRONIC_RESOURCE_Check: 'Electronic Resource', // Deprecated, need to be removed after all tests will be updated
+  PE_MIX: 'P/E mix',
+  PE_MIX_Check: 'P/E Mix',
+  OTHER: 'Other',
+  PHYSICAL_RESOURCE: 'Physical resource',
+  PHYSICAL_RESOURCE_Check: 'Physical Resource', // Deprecated, need to be removed after all tests will be updated
+};
+
+export const ORDER_PAYMENT_STATUS = {
+  PENDING: 'Pending',
+  PAYMENT_NOT_REQUIRED: 'Payment not required',
+};
+
+export const ACQUISITION_METHOD_NAMES_IN_PROFILE = {
+  APPROVAL_PLAN: 'Approval plan',
+  PURCHASE: 'Purchase',
+  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase at vendor system',
+  OTHER: 'Other',
+};
+
+export const RECEIPT_STATUS_SELECTED = {
+  PENDING: 'Pending',
+  RECEIPT_NOT_REQUIRED: 'Receipt not required',
+};
+
+export const RECEIPT_STATUS_VIEW = {
+  AWAITING_RECEIPT: 'Awaiting receipt',
+  CANCELLED: 'Cancelled',
+  PENDING: 'Pending',
+  FULLY_RECEIVED: 'Fully received',
+  ONGOING: 'Ongoing',
+  PARTIALLY_RECEIVED: 'Partially received',
+  RECEIPT_NOT_REQUIRED: 'Receipt not required',
+};
+
+export const RECEIVING_WORKFLOW_NAMES = {
+  SYNCHRONIZED_ORDER_AND_RECEIPT_QUANTITY: 'Synchronized order and receipt quantity',
+  INDEPENDENT_ORDER_AND_RECEIPT_QUANTITY: 'Independent order and receipt quantity',
+};
+
+export const ACQUISITION_METHOD_NAMES = {
+  APPROVAL_PLAN: 'Approval plan',
+  DDA: 'Demand driven acquisitions (DDA)',
+  DEPOSITORY: 'Depository',
+  EBA: 'Evidence based acquisitions (EBA)',
+  EXCHANGE: 'Exchange',
+  FREE: 'Free',
+  GIFT: 'Gift',
+  INTERNAL_TRANSFER: 'Internal transfer',
+  MEMBERSHIP: 'Membership',
+  OTHER: 'Other',
+  PURCHASE: 'Purchase',
+  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase At Vendor System',
+  TECHNICAL: 'Technical',
+};
+
+export const ACQUISITION_METHOD_NAMES_IN_MAPPING_PROFILES = {
+  APPROVAL_PLAN: 'Approval Plan',
+  DDA: 'Demand Driven Acquisitions (DDA)',
+  DEPOSITORY: 'Depository',
+  EBA: 'Evidence Based Acquisitions (EBA)',
+  EXCHANGE: 'Exchange',
+  FREE: 'Free',
+  GIFT: 'Gift',
+  INTERNAL_TRANSFER: 'Internal transfer',
+  MEMBERSHIP: 'Membership',
+  OTHER: 'Other',
+  PURCHASE: 'Purchase',
+  PURCHASE_AT_VENDOR_SYSTEM: 'Purchase At Vendor System',
+  TECHNICAL: 'Technical',
+};
+
+export const POL_CREATE_INVENTORY_SETTINGS = {
+  INSTANCE: 'Instance',
+  INSTANCE_HOLDING: 'Instance, Holding',
+  INSTANCE_HOLDING_ITEM: 'Instance, Holding, Item',
+  NONE: 'None',
+};
+
+export const POL_CREATE_INVENTORY_SETTINGS_VIEW = {
+  INSTANCE: 'Instance',
+  INSTANCE_HOLDING: 'Instance, holdings',
+  INSTANCE_HOLDING_ITEM: 'Instance, holdings, item',
+  NONE: 'None',
+};
+
+export const POLINE_DETAILS_FIELDS = {
+  ORDER_FORMAT: 'Order format',
+  RECEIPT_STATUS: 'Receipt status',
+  PAYMENT_STATUS: 'Payment status',
+  HOLDING_NAME: 'Holding',
+  LOCATION_NAME: 'Name (code)',
+  PHYSICAL_UNIT_PRICE: 'Physical unit price',
+  QUANTITY_PHYSICAL: 'Quantity physical',
+  ELECTRONIC_UNIT_PRICE: 'Electronic unit price',
+  QUANTITY_ELECTRONIC: 'Quantity electronic',
+  CREATE_INVENTORY: 'Create inventory',
+};

--- a/cypress/support/constants/orders/order.js
+++ b/cypress/support/constants/orders/order.js
@@ -1,0 +1,31 @@
+export const ORDER_TYPES = {
+  ONE_TIME: 'One-time',
+  ONGOING: 'Ongoing',
+};
+
+export const ORDER_STATUSES = {
+  OPEN: 'Open',
+  PENDING: 'Pending',
+  CLOSED: 'Closed',
+};
+
+export const ORDER_SYSTEM_CLOSING_REASONS = {
+  CANCELLED: 'Cancelled',
+  CEASED: 'Ceased',
+  COMPLETE: 'Complete',
+  TRANSFERRED_TO_ANOTHER_PUBLISHER: 'Transferred to another publisher',
+  MERGED_WITH_ANOTHER_TITLE: 'Merged with another title',
+  SPLIT_INTO_OTHER_TITLES: 'Split into other titles',
+  LACK_OF_FUNDS: 'Lack of funds',
+  LACK_OF_USE: 'Lack of use',
+  DUPLICATION: 'Duplication',
+  UNRESPONSIVE_VENDOR: 'Unresponsive vendor',
+  LICENSING_TERMS: 'Licensing terms (unacceptable)',
+  LOW_QUALITY: 'Low quality',
+  UNPREFERRED_FORMAT: 'Unpreferred format',
+  ERROR: 'Error',
+  TITLE_WONT_BE_PUBLISHED_THIS_YEAR: "Title won't be published this year",
+  TITLE_WONT_BE_PUBLISHED: "Title won't be published",
+  TITLE_OUT_OF_PRINT: 'Title is out of print',
+  TITLE_RECEIVED_AS_GIFT: 'Title received as a gift',
+};

--- a/cypress/support/constants/organizations/index.js
+++ b/cypress/support/constants/organizations/index.js
@@ -1,0 +1,5 @@
+export const ORGANIZATION_STATUSES = {
+  ACTIVE: 'Active',
+  INACTIVE: 'Inactive',
+  PENDING: 'Pending',
+};

--- a/cypress/support/constants/receiving/index.js
+++ b/cypress/support/constants/receiving/index.js
@@ -1,0 +1,9 @@
+export const RECEIVING_TITLE_ACCORDION_NAMES = {
+  TITLE_INFORMATION: 'Title information',
+  POL_DETAILS: 'POL details',
+  EXPECTED: 'Expected',
+  RECEIVED: 'Received',
+  ROUTING_LISTS: 'Routing lists',
+  UNRECEIVABLE: 'Unreceivable',
+  BOUND_ITEMS: 'Bound items',
+};


### PR DESCRIPTION
Keeping all constants in a single file becomes extremely difficult to maintain. It also leads to code duplication, as it’s hard to find an existing constant among so many.

This PR handles only the Acquisitions team-related constants.