### PR TITLE
FAT-25703: Fix login flow in tags-functionality test to use path and waiter options

### DIFF
--- a/cypress/e2e/inventory/tags/tags-functionality.cy.js
+++ b/cypress/e2e/inventory/tags/tags-functionality.cy.js
@@ -475,8 +475,10 @@ describe('Inventory', () => {
     });
 
     beforeEach('Login', () => {
-      cy.login(userData.username, userData.password);
-      cy.visit(TopMenu.inventoryPath);
+      cy.login(userData.username, userData.password, {
+        path: TopMenu.inventoryPath,
+        waiter: InventoryInstances.waitContentLoading,
+      });
     });
 
     after('Deleting created entities', () => {


### PR DESCRIPTION
## Issues

[FAT-25703](https://folio-org.atlassian.net/browse/FAT-25703)

## Summary

Updated the `beforeEach` login block in the tags-functionality Cypress test to use `cy.login` with `path` and `waiter` options instead of a separate `cy.visit` call. This ensures the Inventory page is fully loaded before the test proceeds, improving test stability.

It fixes https://report-portal.ci.folio.org/ui/#cypress-nightly/launches/all/8967/3895144/3895145/3895169/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dab001%252Cab_r1iwnb0flisk%252Cab_uvbcfwkvo3e8%26filter.cnt.name%3Dvolaris%26page.page%3D1