### PR TITLE
Fix c591

### DIFF
--- a/cypress/e2e/checkout/checkout.multipiece.items.cy.js
+++ b/cypress/e2e/checkout/checkout.multipiece.items.cy.js
@@ -15,7 +15,6 @@ import OtherSettings from '../../support/fragments/settings/circulation/otherSet
 
 describe('Check out', () => {
   let user = {};
-  let userBarcode;
   let servicePoint;
   let materialTypeName;
   let testInstanceIds;
@@ -78,12 +77,10 @@ describe('Check out', () => {
           testInstanceIds = specialInstanceIds;
         });
       });
-    cy.createTempUser([permissions.checkoutCirculatingItems.gui])
-      .then((userProperties) => {
-        user = userProperties;
-        userBarcode = userProperties.barcode;
-        UserEdit.addServicePointViaApi(servicePoint.id, user.userId, servicePoint.id);
-      });
+    cy.createTempUser([permissions.checkoutCirculatingItems.gui]).then((userProperties) => {
+      user = userProperties;
+      UserEdit.addServicePointViaApi(servicePoint.id, user.userId, servicePoint.id);
+    });
 
     // Fetching the current "Other settings" values.
     // Checking if "Patron id(s) for checkout scanning" is enabled by "ID".
@@ -143,8 +140,8 @@ describe('Check out', () => {
         path: TopMenu.checkOutPath,
         waiter: Checkout.waitLoading,
       });
-      CheckOutActions.checkOutItemUser(userBarcode, testItems[0].barcode);
-      CheckOutActions.checkPatronInformation(user.username, userBarcode);
+      CheckOutActions.checkOutItemUser(user.userId, testItems[0].barcode);
+      CheckOutActions.checkPatronInformation(user.username, user.userId);
       cy.expect(CheckOutActions.modal.absent());
 
       fullCheckOut(testItems[1]);


### PR DESCRIPTION
## Purpose
Fixed an issue in c591. In foliotest steps where the id was being provided, but the code was attempting to use the barcode instead.

<img width="503" height="232" alt="image" src="https://github.com/user-attachments/assets/d706c63a-9728-4865-b60b-26bf5ac0a397" />

# Refs
https://folio-org.atlassian.net/browse/FAT-25900