### PR TITLE
FAT-26027 Automate test case C1259783 for the query builder

### DIFF
--- a/cypress/e2e/lists/query-builder/search-query-builder-ui.cy.js
+++ b/cypress/e2e/lists/query-builder/search-query-builder-ui.cy.js
@@ -214,6 +214,11 @@ describe('Lists', () => {
       const recordType = 'Instances';
       const testData = {
         instanceTitle: getTestEntityValue('C_lists_query_builder_classification_instance'),
+        uuidInstanceTitles: [
+          getTestEntityValue('C446019_Instance_1'),
+          getTestEntityValue('C446019_Instance_2'),
+        ],
+        instanceIds: [],
         classificationNumber: 'BJ1533.C4',
         classificationIdentifierTypeName: getTestEntityValue(
           'C_lists_query_builder_classification_type',
@@ -243,6 +248,17 @@ describe('Lists', () => {
             },
           }).then(({ instanceId }) => {
             testData.instanceId = instanceId;
+            testData.instanceIds.push(instanceId);
+          });
+          testData.uuidInstanceTitles.forEach((title) => {
+            InventoryInstances.createFolioInstanceViaApi({
+              instance: {
+                instanceTypeId: instanceTypes[0].id,
+                title,
+              },
+            }).then(({ instanceId }) => {
+              testData.instanceIds.push(instanceId);
+            });
           });
         });
         createQueryBuilderUser(
@@ -255,6 +271,11 @@ describe('Lists', () => {
         cy.getAdminToken();
         Users.deleteViaApi(userData.userId);
         InventoryInstance.deleteInstanceViaApi(testData.instanceId);
+        testData.instanceIds
+          .filter((instanceId) => instanceId !== testData.instanceId)
+          .forEach((instanceId) => {
+            InventoryInstance.deleteInstanceViaApi(instanceId);
+          });
         ClassificationIdentifierTypes.deleteViaApi(testData.classificationIdentifierTypeId);
       });
 
@@ -339,6 +360,65 @@ describe('Lists', () => {
           QueryModal.testQueryDisabled(false);
           QueryModal.verifyRowDoesNotContain('eng');
           QueryModal.verifyQueryAreaDoesNotContain('undefined');
+        },
+      );
+
+      it(
+        'C446019 The IN operator is rendered correctly in the query builder when editing existing queries (corsair)',
+        { tags: ['criticalPath', 'corsair', 'C446019'] },
+        () => {
+          const recordAmount = 3;
+          const instanceIds = testData.instanceIds;
+          const value = instanceIds.join(',');
+          const formattedValue = instanceIds.join(', ');
+          const expectedQuery = `(instance.id in (${formattedValue}))`;
+
+          listName = getTestEntityValue('C446019_List');
+          openQueryBuilder(recordType);
+
+          QueryModal.selectField(instanceFieldValues.instanceId);
+          QueryModal.verifySelectedField(instanceFieldValues.instanceId);
+          QueryModal.selectOperator(QUERY_OPERATIONS.IN);
+          QueryModal.fillInValueTextfield(value);
+          QueryModal.verifyTextFieldValue(value);
+          QueryModal.verifyQueryAreaContent(expectedQuery);
+          QueryModal.testQueryDisabled(false);
+          QueryModal.runQueryDisabled();
+
+          QueryModal.clickTestQuery();
+          QueryModal.verifyPreviewOfRecordsMatched();
+          QueryModal.verifyNumberOfMatchedRecords(recordAmount);
+          instanceIds.forEach((instanceId) => {
+            QueryModal.verifyRecordWithContent(instanceId);
+          });
+
+          QueryModal.clickRunQueryAndSave();
+          QueryModal.verifyClosed();
+          Lists.verifySuccessCalloutMessage(`List ${listName} saved.`);
+          Lists.waitForCompilingAnimationToDisappear();
+          Lists.verifyRefreshCompleteCallout(recordAmount);
+          Lists.viewUpdatedList();
+          Lists.verifyRecordsNumber(recordAmount);
+          instanceIds.forEach((instanceId) => {
+            Lists.verifyRecordWithContent(instanceId);
+          });
+
+          Lists.openActions();
+          Lists.editList();
+          Lists.editQuery();
+          QueryModal.verifySelectedField(instanceFieldValues.instanceId);
+          QueryModal.verifySelectedOperator(QUERY_OPERATIONS.IN);
+          QueryModal.verifyTextFieldValue(value);
+          QueryModal.verifyQueryAreaDoesNotContain('undefined');
+          QueryModal.testQueryDisabled(false);
+          QueryModal.runQueryDisabled();
+
+          QueryModal.clickTestQuery();
+          QueryModal.verifyPreviewOfRecordsMatched();
+          QueryModal.verifyNumberOfMatchedRecords(recordAmount);
+          instanceIds.forEach((instanceId) => {
+            QueryModal.verifyRecordWithContent(instanceId);
+          });
         },
       );
 

--- a/cypress/e2e/lists/query-builder/search-query-builder-ui.cy.js
+++ b/cypress/e2e/lists/query-builder/search-query-builder-ui.cy.js
@@ -61,13 +61,16 @@ describe('Lists', () => {
       }
     };
 
-    const openQueryBuilder = (recordType) => {
+    const openQueryBuilder = (recordType, description) => {
       cy.login(userData.username, userData.password, {
         path: TopMenu.listsPath,
         waiter: Lists.waitLoading,
       });
       Lists.openNewListPane();
       Lists.setName(listName);
+      if (description) {
+        Lists.setDescription(description);
+      }
       Lists.selectRecordType(recordType);
       Lists.buildQuery();
     };
@@ -230,6 +233,7 @@ describe('Lists', () => {
             instance: {
               instanceTypeId: instanceTypes[0].id,
               title: testData.instanceTitle,
+              languages: ['eng'],
               classifications: [
                 {
                   classificationNumber: testData.classificationNumber,
@@ -273,6 +277,68 @@ describe('Lists', () => {
             'list-column-instance.discovery_suppress',
             'False',
           );
+        },
+      );
+
+      it(
+        'C1259783 Verify that no undefined values are displayed when editing a query (corsair)',
+        { tags: ['smoke', 'corsair', 'C1259783'] },
+        () => {
+          const language = 'English';
+          const recordAmount = 1;
+          const expectedLanguageQuery = `(instance.languages in [${language}])`;
+          const expectedQuery = `${expectedLanguageQuery} AND (instance.title == ${testData.instanceTitle})`;
+
+          listName = getTestEntityValue('C1259783_List');
+          openQueryBuilder(recordType, listName);
+
+          QueryModal.selectField(instanceFieldValues.languages);
+          QueryModal.verifySelectedField(instanceFieldValues.languages);
+          QueryModal.selectOperator(QUERY_OPERATIONS.EQUAL);
+          QueryModal.chooseValueSelect(language);
+          QueryModal.verifySelectedValue(language);
+          QueryModal.verifyQueryAreaContent(`(instance.languages == ${language})`);
+
+          QueryModal.selectOperator(QUERY_OPERATIONS.IN);
+          QueryModal.verifySelectedMultiselectValue(language);
+          QueryModal.verifyQueryAreaContent(expectedLanguageQuery);
+          QueryModal.verifyQueryAreaDoesNotContain('undefined');
+
+          QueryModal.addNewRow();
+          QueryModal.selectField(instanceFieldValues.instanceResourceTitle, 1);
+          QueryModal.verifySelectedField(instanceFieldValues.instanceResourceTitle, 1);
+          QueryModal.selectOperator(QUERY_OPERATIONS.EQUAL, 1);
+          QueryModal.fillInValueTextfield(testData.instanceTitle, 1);
+          QueryModal.verifyTextFieldValue(testData.instanceTitle, 1);
+          QueryModal.verifyQueryAreaContent(expectedQuery);
+          QueryModal.verifyQueryAreaDoesNotContain('undefined');
+
+          QueryModal.clickTestQuery();
+          QueryModal.verifyPreviewOfRecordsMatched();
+          QueryModal.verifyNumberOfMatchedRecords(recordAmount);
+          QueryModal.verifyRecordWithContent(testData.instanceTitle);
+          QueryModal.clickRunQueryAndSave();
+          QueryModal.verifyClosed();
+          Lists.verifySuccessCalloutMessage(`List ${listName} saved.`);
+          Lists.waitForCompilingAnimationToDisappear();
+          Lists.verifyRefreshCompleteCallout(recordAmount);
+          Lists.viewUpdatedList();
+          Lists.verifySingleRecordNumber();
+          Lists.verifyRecordWithContent(testData.instanceTitle);
+
+          Lists.openActions();
+          Lists.editList();
+          Lists.editQuery();
+          QueryModal.verifySelectedField(instanceFieldValues.languages);
+          QueryModal.verifySelectedOperator(QUERY_OPERATIONS.IN);
+          QueryModal.verifySelectedMultiselectValue(language);
+          QueryModal.verifySelectedField(instanceFieldValues.instanceResourceTitle, 1);
+          QueryModal.verifySelectedOperator(QUERY_OPERATIONS.EQUAL, 1);
+          QueryModal.verifyTextFieldValue(testData.instanceTitle, 1);
+          QueryModal.verifyQueryAreaContent(expectedQuery);
+          QueryModal.testQueryDisabled(false);
+          QueryModal.verifyRowDoesNotContain('eng');
+          QueryModal.verifyQueryAreaDoesNotContain('undefined');
         },
       );
 

--- a/cypress/support/fragments/bulk-edit/query-modal.js
+++ b/cypress/support/fragments/bulk-edit/query-modal.js
@@ -421,6 +421,18 @@ export default {
     cy.wait(1000);
   },
 
+  verifySelectedOperator(selection, row = 0) {
+    cy.expect(
+      RepeatableFieldItem({ index: row })
+        .find(Select({ dataTestID: including('operator-option') }))
+        .has({ checkedOptionText: selection }),
+    );
+  },
+
+  verifyRowDoesNotContain(content, row = 0) {
+    cy.get(`[data-testid="row-${row}"]`).should('not.contain.text', content);
+  },
+
   verifyOperatorsList(operators, row = 0) {
     cy.get(`[data-testid="row-${row}"] [class^="col-sm-2"] [class^="selectControl"] option`).then(
       (options) => {
@@ -436,6 +448,12 @@ export default {
 
   verifyQueryAreaContent(content) {
     cy.get('[class^="queryArea"]').should('have.text', content);
+  },
+
+  verifyQueryAreaDoesNotContain(content) {
+    cy.get('[class^="queryArea"]').should(($queryArea) => {
+      expect($queryArea.text().toLowerCase()).not.to.include(content.toLowerCase());
+    });
   },
 
   verifyQueryTextboxReadOnly() {
@@ -754,6 +772,10 @@ export default {
 
   verifyNumberOfRowsInPreviewTable(expectedNumberOfRows) {
     cy.expect(MultiColumnList().has({ rowCount: expectedNumberOfRows }));
+  },
+
+  verifyRecordWithContent(content) {
+    cy.expect(buildQueryModal.find(MultiColumnListCell({ content })).exists());
   },
 
   verifyQueryReturnsNoResults() {

--- a/cypress/support/fragments/bulk-edit/query-modal.js
+++ b/cypress/support/fragments/bulk-edit/query-modal.js
@@ -750,7 +750,7 @@ export default {
     this.testQueryDisabled(false);
     this.cancelDisabled(false);
     this.runQueryDisabled(false);
-    cy.get('[class^="col-xs-10"]').then(($element) => {
+    cy.contains('h3', /^Query returns/).then(($element) => {
       cy.wrap($element)
         .invoke('text')
         .then((text) => {
@@ -870,7 +870,7 @@ export default {
 
   verifyNumberOfMatchedRecords(numberOfMatchedRecords) {
     cy.wait(3000);
-    cy.get('[class^="col-xs-10"]').then(($element) => {
+    cy.contains('h3', /^Query returns/).then(($element) => {
       cy.wrap($element)
         .invoke('text')
         .then((text) => {

--- a/cypress/support/fragments/lists/lists.js
+++ b/cypress/support/fragments/lists/lists.js
@@ -539,8 +539,27 @@ const UI = {
     cy.get('#results-viewer-accordion').contains(`${number} records found`).should('be.visible');
   },
 
+  verifySingleRecordNumber() {
+    cy.get('[class^=paneHeader-]').contains('1 record found').should('be.visible');
+    cy.get('#results-viewer-accordion').contains('1 record found').should('be.visible');
+  },
+
   verifyQuery(query) {
     cy.get('#results-viewer-accordion').contains(`Query: (${query})`).should('be.visible');
+  },
+
+  verifyRecordWithContent(content) {
+    cy.expect(MultiColumnListCell({ content }).exists());
+  },
+
+  waitForCompilingAnimationToDisappear() {
+    cy.get('[class^=compilerWrapper]', { timeout: 120000 }).should('not.exist');
+  },
+
+  verifyRefreshCompleteCallout(recordsCount) {
+    cy.contains(`Refresh complete with ${recordsCount} records: View updated list`, {
+      timeout: 90000,
+    }).should('be.visible');
   },
 
   openList(listName) {


### PR DESCRIPTION
The test creates an Instances list with an English language query, changes the operator from equals to in, saves and refreshes the list, then reopens Edit query to verify the user-friendly query and prefilled values display English without undefined values.The test creates an Instances list with an English language query, changes the operator from equals to in, saves and refreshes the list, then reopens Edit query to verify the user-friendly query and prefilled values display English without undefined values.