### PR TITLE
Suppress Chrome sandbox and GPU errors in CI

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -47,6 +47,14 @@ try {
  */
 async function setupAfterSpecChaining(on, config) {
   if (config.env.itemsFilePath) {
+    on('before:browser:launch', (browser, launchOptions) => {
+      if (browser.family === 'chromium') {
+        launchOptions.args.push('--no-sandbox');
+        launchOptions.args.push('--disable-gpu');
+      }
+      return launchOptions;
+    });
+
     let testRailAfterSpecHandler;
 
     // Intercept after:spec registration from TestRail plugin


### PR DESCRIPTION
## Summary

Running `node scripts/report-portal/runFailedTests.js --launchName runNightlyCypressEurekaTests` shows the following errors in Jenkins container logs, which actually do not affect anything, but confuse people.

```
17:48:16  [5815:0528/144816.559731:ERROR:zygote_host_impl_linux.cc(263)] Failed to adjust OOM score of renderer with pid 5970: Permission denied (13)
17:48:16  [5970:0528/144816.574743:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
```

Added a `before:browser:launch` handler that injects two Chrome flags when running in a Chromium-family browser:
* `--no-sandbox` — removes the sandbox that requires OOM-score adjustment privileges (fixes the `zygote_host_impl_linux.cc` error)
* `--disable-gpu` — disables GPU hardware acceleration (fixes the `gpu_memory_buffer_support_x11.cc` / dri3 error)

These errors are caused by Chrome's sandbox requiring elevated OS privileges and GPU/X11 access that are unavailable in containerized CI agents.

The `before:browser:launch` handler is inside `setupAfterSpecChaining`'s `itemsFilePath` guard — it only activates when running the `runFailedTests.js` script. Regular Cypress runs (local dev, CI pipelines that invoke Cypress directly) are unaffected.

Here are args available for the [Chromium-based browsers](https://peter.sh/experiments/chromium-command-line-switches/).

