### PR TITLE
Write flaky recheck count to file

### DIFF
--- a/scripts/report-portal/runFailedTests.js
+++ b/scripts/report-portal/runFailedTests.js
@@ -172,6 +172,8 @@ async function main() {
       );
     }
 
+    fs.writeFileSync('flaky-recheck-count.txt', String(totalMarked));
+
     process.exit(0);
   } catch (error) {
     console.error(`\n✗ Error: ${error.message}`);


### PR DESCRIPTION
Persist the totalMarked value to flaky-recheck-count.txt in scripts/report-portal/runFailedTests.js so CI or downstream scripts can read the number of rechecked/flaky tests. Adds an fs.writeFileSync call before process exit to improve visibility of flaky test counts.