### PR TITLE
FAT-24746 Thunderjet - Create Cypress tests - [Receiving] ""Add piece"" action is not displayed in ""Receiving"" app when related order has ""Pending"" status and ""Synchronized"" workflow

### DIFF
--- a/cypress/e2e/receiving/add-piece-action-not-displayed-for-pending-order-with-synchronized-workflow.cy.js
+++ b/cypress/e2e/receiving/add-piece-action-not-displayed-for-pending-order-with-synchronized-workflow.cy.js
@@ -23,46 +23,64 @@ describe('Receiving', () => {
   before('Create test data', () => {
     cy.getAdminToken();
     Organizations.createOrganizationViaApi(testData.organization).then(() => {
-      testData.orderLinePhysical = {
-        ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
-        orderFormat: 'Physical Resource',
-        physical: {
-          createInventory: 'Instance, Holding, Item',
-          materialSupplier: testData.organization.id,
-          volumes: [],
-        },
-      };
-      testData.orderLineElectronic = {
-        ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
-        orderFormat: 'Electronic Resource',
-        cost: {
-          listUnitPriceElectronic: 1.0,
-          currency: 'USD',
-          discountType: 'percentage',
-          quantityElectronic: 1,
-          poLineEstimatedPrice: 1.0,
-        },
-        eresource: {
-          activated: false,
-          createInventory: 'Instance, Holding',
-          trial: false,
-          accessProvider: testData.organization.id,
-        },
-        locations: [],
-      };
+      cy.getLocations({ limit: 1 }).then((location) => {
+        cy.getDefaultMaterialType().then((materialType) => {
+          testData.orderLinePhysical = {
+            ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
+            orderFormat: 'Physical Resource',
+            physical: {
+              createInventory: 'Instance, Holding, Item',
+              materialSupplier: testData.organization.id,
+              materialType: materialType.id,
+              volumes: [],
+            },
+            locations: [
+              {
+                locationId: location.id,
+                quantity: 1,
+                quantityPhysical: 1,
+              },
+            ],
+          };
+          testData.orderLineElectronic = {
+            ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
+            orderFormat: 'Electronic Resource',
+            cost: {
+              listUnitPriceElectronic: 1.0,
+              currency: 'USD',
+              discountType: 'percentage',
+              quantityElectronic: 1,
+              poLineEstimatedPrice: 1.0,
+            },
+            eresource: {
+              activated: false,
+              createInventory: 'Instance, Holding',
+              trial: false,
+              accessProvider: testData.organization.id,
+            },
+            locations: [
+              {
+                locationId: location.id,
+                quantity: 1,
+                quantityElectronic: 1,
+              },
+            ],
+          };
 
-      Orders.createOrderWithOrderLineViaApi(
-        NewOrder.getDefaultOrder({ vendorId: testData.organization.id }),
-        testData.orderLinePhysical,
-      ).then((order) => {
-        testData.orderPhysical = order;
-      });
+          Orders.createOrderWithOrderLineViaApi(
+            NewOrder.getDefaultOrder({ vendorId: testData.organization.id }),
+            testData.orderLinePhysical,
+          ).then((order) => {
+            testData.orderPhysical = order;
+          });
 
-      Orders.createOrderWithOrderLineViaApi(
-        NewOrder.getDefaultOngoingOrder({ vendorId: testData.organization.id }),
-        testData.orderLineElectronic,
-      ).then((order) => {
-        testData.orderElectronic = order;
+          Orders.createOrderWithOrderLineViaApi(
+            NewOrder.getDefaultOngoingOrder({ vendorId: testData.organization.id }),
+            testData.orderLineElectronic,
+          ).then((order) => {
+            testData.orderElectronic = order;
+          });
+        });
       });
     });
 

--- a/cypress/e2e/receiving/add-piece-action-not-displayed-for-pending-order-with-synchronized-workflow.cy.js
+++ b/cypress/e2e/receiving/add-piece-action-not-displayed-for-pending-order-with-synchronized-workflow.cy.js
@@ -8,6 +8,10 @@ import Receiving from '../../support/fragments/receiving/receiving';
 import ReceivingDetails from '../../support/fragments/receiving/receivingDetails';
 import TopMenu from '../../support/fragments/topMenu';
 import Users from '../../support/fragments/users/users';
+import {
+  ORDER_FORMAT_NAMES_IN_PROFILE,
+  POL_CREATE_INVENTORY_SETTINGS,
+} from '../../support/constants/orders/order-line';
 
 describe('Receiving', () => {
   const organization = NewOrganization.getDefaultOrganization();
@@ -27,9 +31,9 @@ describe('Receiving', () => {
         cy.getDefaultMaterialType().then((materialType) => {
           testData.orderLinePhysical = {
             ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
-            orderFormat: 'Physical Resource',
+            orderFormat: ORDER_FORMAT_NAMES_IN_PROFILE.PHYSICAL_RESOURCE,
             physical: {
-              createInventory: 'Instance, Holding, Item',
+              createInventory: POL_CREATE_INVENTORY_SETTINGS.INSTANCE_HOLDING_ITEM,
               materialSupplier: testData.organization.id,
               materialType: materialType.id,
               volumes: [],
@@ -44,7 +48,7 @@ describe('Receiving', () => {
           };
           testData.orderLineElectronic = {
             ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
-            orderFormat: 'Electronic Resource',
+            orderFormat: ORDER_FORMAT_NAMES_IN_PROFILE.ELECTRONIC_RESOURCE,
             cost: {
               listUnitPriceElectronic: 1.0,
               currency: 'USD',
@@ -54,7 +58,7 @@ describe('Receiving', () => {
             },
             eresource: {
               activated: false,
-              createInventory: 'Instance, Holding',
+              createInventory: POL_CREATE_INVENTORY_SETTINGS.INSTANCE_HOLDING,
               trial: false,
               accessProvider: testData.organization.id,
             },

--- a/cypress/e2e/receiving/add-piece-action-not-displayed-for-pending-order-with-synchronized-workflow.cy.js
+++ b/cypress/e2e/receiving/add-piece-action-not-displayed-for-pending-order-with-synchronized-workflow.cy.js
@@ -1,0 +1,113 @@
+import { Permissions } from '../../support/dictionary';
+import BasicOrderLine from '../../support/fragments/orders/basicOrderLine';
+import NewOrder from '../../support/fragments/orders/newOrder';
+import Orders from '../../support/fragments/orders/orders';
+import NewOrganization from '../../support/fragments/organizations/newOrganization';
+import Organizations from '../../support/fragments/organizations/organizations';
+import Receiving from '../../support/fragments/receiving/receiving';
+import ReceivingDetails from '../../support/fragments/receiving/receivingDetails';
+import TopMenu from '../../support/fragments/topMenu';
+import Users from '../../support/fragments/users/users';
+
+describe('Receiving', () => {
+  const organization = NewOrganization.getDefaultOrganization();
+  const testData = {
+    organization,
+    user: {},
+    orderPhysical: {},
+    orderElectronic: {},
+    orderLinePhysical: {},
+    orderLineElectronic: {},
+  };
+
+  before('Create test data', () => {
+    cy.getAdminToken();
+    Organizations.createOrganizationViaApi(testData.organization).then(() => {
+      testData.orderLinePhysical = {
+        ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
+        orderFormat: 'Physical Resource',
+        physical: {
+          createInventory: 'Instance, Holding, Item',
+          materialSupplier: testData.organization.id,
+          volumes: [],
+        },
+      };
+      testData.orderLineElectronic = {
+        ...BasicOrderLine.getDefaultOrderLine({ checkinItems: false }),
+        orderFormat: 'Electronic Resource',
+        cost: {
+          listUnitPriceElectronic: 1.0,
+          currency: 'USD',
+          discountType: 'percentage',
+          quantityElectronic: 1,
+          poLineEstimatedPrice: 1.0,
+        },
+        eresource: {
+          activated: false,
+          createInventory: 'Instance, Holding',
+          trial: false,
+          accessProvider: testData.organization.id,
+        },
+        locations: [],
+      };
+
+      Orders.createOrderWithOrderLineViaApi(
+        NewOrder.getDefaultOrder({ vendorId: testData.organization.id }),
+        testData.orderLinePhysical,
+      ).then((order) => {
+        testData.orderPhysical = order;
+      });
+
+      Orders.createOrderWithOrderLineViaApi(
+        NewOrder.getDefaultOngoingOrder({ vendorId: testData.organization.id }),
+        testData.orderLineElectronic,
+      ).then((order) => {
+        testData.orderElectronic = order;
+      });
+    });
+
+    cy.createTempUser([
+      Permissions.uiInventoryViewInstances.gui,
+      Permissions.uiReceivingViewEditCreate.gui,
+    ]).then((userProperties) => {
+      testData.user = userProperties;
+      cy.login(userProperties.username, userProperties.password, {
+        path: TopMenu.receivingPath,
+        waiter: Receiving.waitLoading,
+      });
+    });
+  });
+
+  after('Delete test data', () => {
+    cy.getAdminToken();
+    Users.deleteViaApi(testData.user.userId);
+    Orders.deleteOrderViaApi(testData.orderPhysical.id);
+    Orders.deleteOrderViaApi(testData.orderElectronic.id);
+    Organizations.deleteOrganizationViaApi(testData.organization.id);
+  });
+
+  it(
+    'C627458 "Add piece" action is not displayed in "Receiving" app when related order has "Pending" status and "Synchronized" workflow (thunderjet)',
+    { tags: ['extendedPath', 'thunderjet', 'C627458'] },
+    () => {
+      // Step 1: Go to title details pane related to POL from Order #1 (One-time, Physical)
+      Receiving.searchByParameter({ value: testData.orderLinePhysical.titleOrPackage });
+      Receiving.selectFromResultsList(testData.orderLinePhysical.titleOrPackage);
+      ReceivingDetails.checkTitlePaneIsDisplayed(testData.orderLinePhysical.titleOrPackage);
+      ReceivingDetails.verifyExpectedRecordsCount(0);
+
+      // Step 2: Click "Actions" in "Expected" accordion — "Add piece" must NOT be present
+      ReceivingDetails.verifyAddPieceButtonAbsent();
+      ReceivingDetails.closeDetailsPane();
+
+      // Step 3: Go to title details pane related to POL from Order #2 (Ongoing, Electronic)
+      Receiving.searchByParameter({ value: testData.orderLineElectronic.titleOrPackage });
+      Receiving.selectFromResultsList(testData.orderLineElectronic.titleOrPackage);
+      ReceivingDetails.checkTitlePaneIsDisplayed(testData.orderLineElectronic.titleOrPackage);
+      ReceivingDetails.verifyExpectedRecordsCount(0);
+
+      // Step 4: Click "Actions" in "Expected" accordion — "Add piece" must NOT be present
+      ReceivingDetails.verifyAddPieceButtonAbsent();
+    },
+  );
+});

--- a/cypress/support/fragments/receiving/receivingDetails.js
+++ b/cypress/support/fragments/receiving/receivingDetails.js
@@ -227,6 +227,10 @@ export default {
     cy.do(buttons.Actions.click());
     cy.expect(Button('Edit').has({ disabled: true }));
   },
+  verifyAddPieceButtonAbsent() {
+    cy.do(expectedSection.find(Button('Actions')).click());
+    cy.expect(Button('Add piece').absent());
+  },
   openReceiveListEditForm() {
     cy.do([expectedSection.find(Button('Actions')).click(), Button('Receive').click()]);
     ReceivingsListEditForm.waitLoading();

--- a/cypress/support/fragments/receiving/receivingDetails.js
+++ b/cypress/support/fragments/receiving/receivingDetails.js
@@ -42,6 +42,8 @@ const receivedRowsSelector = '#received [class*="mclRowFormatterContainer"]';
 const boundItemsAccordion = Section({ id: 'boundItems' });
 const boundItemsList = MultiColumnList({ id: 'bound-items-list' });
 
+const ADD_PIECE_BUTTON_LABEL = 'Add piece';
+
 const buttons = {
   Actions: receinvingDetailsHeader.find(Button('Actions')),
   Edit: Button('Edit'),
@@ -229,7 +231,7 @@ export default {
   },
   verifyAddPieceButtonAbsent() {
     cy.do(expectedSection.find(Button('Actions')).click());
-    cy.expect(Button('Add piece').absent());
+    cy.expect(Button(ADD_PIECE_BUTTON_LABEL).absent());
   },
   openReceiveListEditForm() {
     cy.do([expectedSection.find(Button('Actions')).click(), Button('Receive').click()]);


### PR DESCRIPTION
<img width="1907" height="1009" alt="image" src="https://github.com/user-attachments/assets/5fbee824-72ab-4c9f-a09e-fb081f8634ab" />

Refs: [FAT-24746](https://folio-org.atlassian.net/browse/FAT-24746)