### PR TITLE
Fix 'Cannot check out to inactive user' in C434

### DIFF
--- a/cypress/e2e/users/proxy-relationship-expiration.cy.js
+++ b/cypress/e2e/users/proxy-relationship-expiration.cy.js
@@ -136,6 +136,7 @@ describe('Users', () => {
       cy.getUsers({ limit: 1, query: `"id"="${usersData.userProxy.userId}"` }).then((users) => {
         const proxyUser = users[0];
         proxyUser.expirationDate = DateTools.getPreviousDayDateForFiscalYear();
+        proxyUser.active = false;
         cy.updateUser(proxyUser);
       });
 
@@ -154,6 +155,10 @@ describe('Users', () => {
       cy.getUsers({ limit: 1, query: `"id"="${usersData.userProxy.userId}"` }).then((users) => {
         const proxyUser = users[0];
         proxyUser.expirationDate = DateTools.getDayTomorrowDateForFiscalYear();
+        // When expirationDate is in the past or future, the BE makes a user inactive/active with a delay.
+        // UI implementation doesn't wait for the BE, it sets active to false immediately,
+        // so we also need to set active to true to avoid waiting for BE to make user active.
+        proxyUser.active = true;
         cy.updateUser(proxyUser);
       });
 


### PR DESCRIPTION
Fix the flakiness of https://report-portal.ci.folio.org/ui/#cypress-nightly/launches/all/9271/4390175/4390191/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dti001%26filter.cnt.name%3Dvol%26page.page%3D1

The root cause is:

**Step 5** sets `expirationDate` to yesterday → FOLIO automatically flips `active: false` on the stored user record.
**Step 8** fetches that same user (now with `active: false`), sets only `expirationDate` to tomorrow, and PUTs it back - without setting `active: true`.