### PR TITLE
FAT-26336: Fix `selectTenantIfDropdown` - skip tenant dropdown only for localhost, not all non-ECS envs.

### DIFF
--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -169,8 +169,10 @@ Cypress.Commands.add(
   },
 );
 
+const isLocalhostBaseUrl = () => new URL(Cypress.config('baseUrl')).hostname === 'localhost';
+
 Cypress.Commands.add('selectTenantIfDropdown', () => {
-  if (!Cypress.env('ecsEnabled')) {
+  if (isLocalhostBaseUrl()) {
     return cy.wrap(null, { log: false });
   }
 
@@ -253,9 +255,7 @@ const loginViaKeycloakOnLocalhost = (username, password) => {
 
 Cypress.Commands.add('inputCredentialsAndLogin', (username, password) => {
   if (Cypress.env('eureka')) {
-    const isLocalhostBaseUrl = new URL(Cypress.config('baseUrl')).hostname === 'localhost';
-
-    if (isLocalhostBaseUrl) {
+    if (isLocalhostBaseUrl()) {
       loginViaKeycloakOnLocalhost(username, password);
       return;
     }


### PR DESCRIPTION
Replace `!ecsEnabled` guard in `selectTenantIfDropdown` with `isLocalhostBaseUrl` so that ECS member tenant runs with `ecsEnabled=false` still go through tenant selection. A follow-up of https://github.com/folio-org/stripes-testing/pull/7259