### PR TITLE
FAT-26804: Make sure a rule is added via addRuleViaApi.

### DIFF
--- a/cypress/e2e/patron-notices/recieve-notice-checkin.cy.js
+++ b/cypress/e2e/patron-notices/recieve-notice-checkin.cy.js
@@ -285,9 +285,6 @@ describe('Patron notices', () => {
             failOnStatusCode: false,
           }),
           (response) => response.body.logRecords.length > 0,
-          {
-            timeout: 1200000,
-          },
         );
 
         cy.login(userData.username, userData.password, {

--- a/cypress/support/fragments/circulation/circulation-rules.js
+++ b/cypress/support/fragments/circulation/circulation-rules.js
@@ -220,14 +220,26 @@ export default {
     });
   },
 
-  addRuleViaApi(priorities, ruleProps) {
+  addRuleViaApi(priorities, ruleProps, retries = 5) {
     return this.getViaApi().then(({ rulesAsText }) => {
       const newProps = { ...this.getRuleProps(rulesAsText), ...ruleProps };
       const rulePriority = Object.entries(priorities)
         .map((priority) => priority.join(' '))
         .join(' + ');
       const newRule = `\n${rulePriority}: l ${newProps.l} r ${newProps.r} n ${newProps.n} o ${newProps.o} i ${newProps.i}`;
-      return this.updateCirculationRules(rulesAsText + newRule);
+      return this.updateCirculationRules(rulesAsText + newRule).then((savedRule) => {
+        return this.getViaApi().then(({ rulesAsText: currentRules }) => {
+          if (!currentRules.includes(newRule.trim())) {
+            if (retries <= 0) {
+              throw new Error(
+                'Failed to persist circulation rule: concurrent overwrites exceeded retry limit',
+              );
+            }
+            return this.addRuleViaApi(priorities, ruleProps, retries - 1);
+          }
+          return savedRule;
+        });
+      });
     });
   },
 


### PR DESCRIPTION
The test [C347623](https://report-portal.ci.folio.org/ui/#cypress-nightly/launches/all/9367/4571030/4571031/4571032/log?item0Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dab001%252Cab_r1iwnb0flisk%252Cab_uvbcfwkvo3e8&logParams=history%3D4571032%26page.page%3D1) most probably fails due to a missing rule. The rule can be overwritten by a concurrent test. The applied fix is: after writing, re-read and verify the rule is still present before proceeding (an optimistic lock pattern).

