### PR TITLE
FAT-26874-trillium Deleted constant

### DIFF
--- a/cypress/support/constants/constants.js
+++ b/cypress/support/constants/constants.js
@@ -363,8 +363,6 @@ export const AUTHORITY_QUERY_FIELDS = {
   AUTHORITY_SEE_ALSO_FROM_REFERENCE_TRACING: 'Authority — See also from reference — Tracing',
   AUTHORITY_SEE_ALSO_FROM_REFERENCE_TRACING_TYPE:
     'Authority — See also from reference — Tracing type',
-  AUTHORITY_SEE_FROM_REFERENCE_RELATIONSHIP_TYPE:
-    'Authority — See from reference — Relationship type',
   AUTHORITY_SEE_FROM_REFERENCE_TRACING: 'Authority — See from reference — Tracing',
   AUTHORITY_SEE_FROM_REFERENCE_TRACING_TYPE: 'Authority — See from reference — Tracing type',
   AUTHORITY_SOURCE: 'Authority — Source',


### PR DESCRIPTION
FAT-26874

Removed constant: Authority — See from reference — Relationship type

Affected test case:
https://foliotest.testrail.io/index.php?/cases/view/1292064

<img width="1501" height="833" alt="Screenshot 2026-06-24 at 14 12 13" src="https://github.com/user-attachments/assets/d85dae6c-d747-435f-88f0-9296fe821bba" />
