### PR TITLE
Mark all tests changing approvals setting to run non-parallel

### DIFF
--- a/cypress/e2e/consortia/invoices/pay-invoice-linked-with-pol-created-in-member-tenant.cy.js
+++ b/cypress/e2e/consortia/invoices/pay-invoice-linked-with-pol-created-in-member-tenant.cy.js
@@ -187,7 +187,7 @@ describe('Invoices', () => {
 
     it(
       'C610245 Pay invoice linked with POL created in Member tenant (consortia) (thunderjet)',
-      { tags: ['smokeECS', 'thunderjet', 'C610245'] },
+      { tags: ['smokeECS', 'thunderjet', 'C610245', 'nonParallel'] },
       () => {
         Invoices.searchByNumber(firstInvoice.vendorInvoiceNo);
         Invoices.selectInvoice(firstInvoice.vendorInvoiceNo);

--- a/cypress/e2e/finance/error-message-appears-when-approve-invoice-from-previous-budget.cy.js
+++ b/cypress/e2e/finance/error-message-appears-when-approve-invoice-from-previous-budget.cy.js
@@ -182,7 +182,7 @@ describe('Finance', () => {
   // may be flaky due to concurrency issues because 'Approve and pay in one click' is set to 'false'
   it(
     'C375959 Meaningful error message appears when trying to approve invoice with related fund having only previous budget (thunderjet) (TaaS)',
-    { tags: ['extendedPath', 'thunderjet', 'C375959'] },
+    { tags: ['extendedPath', 'thunderjet', 'C375959', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/finance/transactions/invoice-with-three-invoice-lines-can-not-be-paid-when-available-expenditure-balance-is-less-that-invoice-total.cy.js
+++ b/cypress/e2e/finance/transactions/invoice-with-three-invoice-lines-can-not-be-paid-when-available-expenditure-balance-is-less-that-invoice-total.cy.js
@@ -204,7 +204,7 @@ describe('Finance', () => {
 
     it(
       'C449373 Invoice with three invoice lines can NOT be paid when available expenditure balance is less that invoice total (thunderjet)',
-      { tags: ['criticalPath', 'thunderjet', 'C449373'] },
+      { tags: ['criticalPath', 'thunderjet', 'C449373', 'nonParallel'] },
       () => {
         Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
         Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/finance/transactions/invoice-with-three-invoice-lines-including-credit-can-not-be-paid-when-available-expenditure-balance-is-less-that-invoice-total.cy.js
+++ b/cypress/e2e/finance/transactions/invoice-with-three-invoice-lines-including-credit-can-not-be-paid-when-available-expenditure-balance-is-less-that-invoice-total.cy.js
@@ -219,7 +219,7 @@ describe('Finance', () => {
     // may be flaky due to concurrency issues because 'Approve and pay in one click' is set to 'true'
     it(
       'C496167 Invoice with three invoice lines (including credit) can NOT be paid when available expenditure balance is less that invoice total  (thunderjet)',
-      { tags: ['criticalPath', 'thunderjet', 'C496167'] },
+      { tags: ['criticalPath', 'thunderjet', 'C496167', 'nonParallel'] },
       () => {
         Invoices.searchByNumber(testData.thirdInvoice.vendorInvoiceNo);
         Invoices.selectInvoice(testData.thirdInvoice.vendorInvoiceNo);

--- a/cypress/e2e/finance/transactions/restricted-expenditures-are-calculated-correctly-when-approved-credit-invoice-exists.cy.js
+++ b/cypress/e2e/finance/transactions/restricted-expenditures-are-calculated-correctly-when-approved-credit-invoice-exists.cy.js
@@ -245,7 +245,7 @@ describe('Finance', () => {
 
     it(
       'C496158 Restricted expenditures are calculated correctly when approved credit invoice exists (thunderjet)',
-      { tags: ['criticalPath', 'thunderjet', 'C496158'] },
+      { tags: ['criticalPath', 'thunderjet', 'C496158', 'nonParallel'] },
       () => {
         Invoices.searchByNumber(thirdInvoice.vendorInvoiceNo);
         Invoices.selectInvoice(thirdInvoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FY-order.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-created-in-current-FY-for-previous-FY-order.cy.js
@@ -257,7 +257,7 @@ describe('Invoices', { retries: { runMode: 1 } }, () => {
 
   it(
     'C388564 Approve and pay invoice created in current FY for previous FY without related order (thunderjet) (TaaS)',
-    { tags: ['criticalPathBroken', 'thunderjet', 'C388564'] },
+    { tags: ['criticalPathBroken', 'thunderjet', 'C388564', 'nonParallel'] },
     () => {
       Invoices.createRolloverInvoiceWithFY(
         testData.invoice,

--- a/cypress/e2e/invoices/approve-and-pay-invoice-with-more-than-50-invoice-lines.cy.js
+++ b/cypress/e2e/invoices/approve-and-pay-invoice-with-more-than-50-invoice-lines.cy.js
@@ -181,7 +181,7 @@ describe('Invoices', () => {
 
   it(
     'C446075 Approve & pay invoice with more than 50 invoice lines (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C446075'] },
+    { tags: ['extendedPath', 'thunderjet', 'C446075', 'nonParallel'] },
     () => {
       // Click on Invoice number link
       Invoices.searchByNumber(invoice.invoiceNumber);

--- a/cypress/e2e/invoices/approve-invoice-is-disabled.cy.js
+++ b/cypress/e2e/invoices/approve-invoice-is-disabled.cy.js
@@ -94,7 +94,7 @@ describe('Invoices', () => {
       isApprovePayEnabled: false,
     },
   ].forEach(({ description, isApprovePayEnabled }) => {
-    it(description, { tags: ['criticalPath', 'thunderjet', 'C397321'] }, () => {
+    it(description, { tags: ['criticalPath', 'thunderjet', 'C397321', 'nonParallel'] }, () => {
       setApprovePayValue(isApprovePayEnabled);
 
       // Click on "Vendor invoice number" link

--- a/cypress/e2e/invoices/approve-invoice-with-two-invoice-level-adjustments-for-same-amount.cy.js
+++ b/cypress/e2e/invoices/approve-invoice-with-two-invoice-level-adjustments-for-same-amount.cy.js
@@ -193,7 +193,7 @@ describe('Invoices', () => {
 
   it(
     'C710367 User can approve an invoice with 2 invoice-level adjustments for same amount and expense class (thunderjet)',
-    { tags: ['criticalPath', 'thunderjet', 'C710367'] },
+    { tags: ['criticalPath', 'thunderjet', 'C710367', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/approve-invoice.cy.js
+++ b/cypress/e2e/invoices/approve-invoice.cy.js
@@ -152,7 +152,7 @@ describe('Invoices', () => {
 
   it(
     'C10945 Approve invoice (thunderjet)',
-    { tags: ['criticalPath', 'thunderjet', 'C10945'] },
+    { tags: ['criticalPath', 'thunderjet', 'C10945', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(invoice.vendorInvoiceNo);
       Invoices.selectInvoice(invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/check-error-message-when-approve-invoice-with-invoice-level-adjustment-and-multi-fund-distributed-by-amounts.cy.js
+++ b/cypress/e2e/invoices/check-error-message-when-approve-invoice-with-invoice-level-adjustment-and-multi-fund-distributed-by-amounts.cy.js
@@ -255,7 +255,7 @@ describe('Invoices', () => {
 
   it(
     'C407745 Check error message when approve invoice with an invoice-level adjustment and its invoice line is multi-fund distributed by amounts (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C407745'] },
+    { tags: ['extendedPath', 'thunderjet', 'C407745', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/edit-subscription-info-and-dates-after-approve.cy.js
+++ b/cypress/e2e/invoices/edit-subscription-info-and-dates-after-approve.cy.js
@@ -99,7 +99,7 @@ describe('Invoices', () => {
 
   it(
     'C350952 Allow editing of subscription dates and subscription info after an invoice is approved/paid (thunderjet) (TaaS)',
-    { tags: ['extendedPath', 'thunderjet', 'C350952'] },
+    { tags: ['extendedPath', 'thunderjet', 'C350952', 'nonParallel'] },
     () => {
       cy.getAdminToken();
       Approvals.setApprovePayValueViaApi(false);

--- a/cypress/e2e/invoices/encumbrance-released-pending-payment-created.cy.js
+++ b/cypress/e2e/invoices/encumbrance-released-pending-payment-created.cy.js
@@ -187,7 +187,7 @@ describe('Invoices', () => {
 
   it(
     'C350631 Encumbrance is released and Pending payment/Payment are created successfully (thunderjet) (TaaS)',
-    { tags: ['extendedPath', 'thunderjet', 'C350631'] },
+    { tags: ['extendedPath', 'thunderjet', 'C350631', 'nonParallel'] },
     () => {
       Orders.searchByParameter('PO number', testData.order.poNumber);
       Orders.selectFromResultsList(testData.order.poNumber);

--- a/cypress/e2e/invoices/invoice-approve-invoice.cy.js
+++ b/cypress/e2e/invoices/invoice-approve-invoice.cy.js
@@ -55,7 +55,7 @@ describe('Invoices', () => {
 
   it(
     'C196776 Invoice: approve invoice (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C196776'] },
+    { tags: ['extendedPath', 'thunderjet', 'C196776', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/invoice-line-can-be-created-from-po-line-in-different-currency.cy.js
+++ b/cypress/e2e/invoices/invoice-line-can-be-created-from-po-line-in-different-currency.cy.js
@@ -197,7 +197,7 @@ describe('Invoices', () => {
 
   it(
     'C411677 Invoice line can be created from PO line in different currency (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C411677'] },
+    { tags: ['extendedPath', 'thunderjet', 'C411677', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/invoice-paid-status-after-approve-and-pay.cy.js
+++ b/cypress/e2e/invoices/invoice-paid-status-after-approve-and-pay.cy.js
@@ -104,7 +104,7 @@ describe('Invoices', () => {
 
   it(
     'C350620 Invoice is in "Paid" status after "Approve & pay" (thunderjet) (TaaS)',
-    { tags: ['extendedPath', 'thunderjet', 'C350620'] },
+    { tags: ['extendedPath', 'thunderjet', 'C350620', 'nonParallel'] },
     () => {
       Invoices.createDefaultInvoiceWithoutAddress(invoice);
       Invoices.checkCreatedInvoice(invoice);

--- a/cypress/e2e/invoices/invoice-pay-invoice.cy.js
+++ b/cypress/e2e/invoices/invoice-pay-invoice.cy.js
@@ -59,7 +59,7 @@ describe('Invoices', () => {
 
   it(
     'C196779 Invoice: Pay invoices (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C196779'] },
+    { tags: ['extendedPath', 'thunderjet', 'C196779', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/invoices-create-credit-invoice.cy.js
+++ b/cypress/e2e/invoices/invoices-create-credit-invoice.cy.js
@@ -47,7 +47,7 @@ describe('Invoices', () => {
 
   it(
     'C343209 Create, approve and pay a credit invoice (thunderjet)',
-    { tags: ['smoke', 'thunderjet', 'C343209', 'shiftLeft'] },
+    { tags: ['smoke', 'thunderjet', 'C343209', 'shiftLeft', 'nonParallel'] },
     () => {
       Invoices.createDefaultInvoice(invoice, vendorPrimaryAddress);
       Invoices.createInvoiceLine(invoiceLine);

--- a/cypress/e2e/invoices/pay-invoice-with-acquisition-unit-user-does-not-belong-to.cy.js
+++ b/cypress/e2e/invoices/pay-invoice-with-acquisition-unit-user-does-not-belong-to.cy.js
@@ -211,7 +211,7 @@ describe('Invoices', () => {
 
   it(
     'C630444 Invoice created based on POL with acquisition unit can be paid by user that does not belong to that acquisition unit ("Approve & pay" option is NOT active) (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C630444'] },
+    { tags: ['extendedPath', 'thunderjet', 'C630444', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/pay-invoice-with-total-value-zero.cy.js
+++ b/cypress/e2e/invoices/pay-invoice-with-total-value-zero.cy.js
@@ -205,7 +205,7 @@ describe('Invoices', () => {
 
   it(
     'C357038 Pay Invoice with total value = 0 (one of the fund distribution has negative amount) (thunderjet) (TaaS)',
-    { tags: ['extendedPath', 'thunderjet', 'C357038'] },
+    { tags: ['extendedPath', 'thunderjet', 'C357038', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/pay-invoice.cy.js
+++ b/cypress/e2e/invoices/pay-invoice.cy.js
@@ -128,32 +128,36 @@ describe('Invoices', () => {
     Users.deleteViaApi(testData.user.userId);
   });
 
-  it('C3453 Pay invoice (thunderjet)', { tags: ['criticalPath', 'thunderjet', 'C3453'] }, () => {
-    Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
-    Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);
-    Invoices.waitLoading();
-    Invoices.payInvoice();
-    InvoiceView.verifyStatus(INVOICE_STATUSES.PAID);
-    Invoices.selectInvoiceLine();
-    InvoiceLineDetails.waitLoading();
-    InvoiceLineDetails.openFundDetailsPane(testData.fund.name);
-    FundDetails.waitLoading();
+  it(
+    'C3453 Pay invoice (thunderjet)',
+    { tags: ['criticalPath', 'thunderjet', 'C3453', 'nonParallel'] },
+    () => {
+      Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
+      Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);
+      Invoices.waitLoading();
+      Invoices.payInvoice();
+      InvoiceView.verifyStatus(INVOICE_STATUSES.PAID);
+      Invoices.selectInvoiceLine();
+      InvoiceLineDetails.waitLoading();
+      InvoiceLineDetails.openFundDetailsPane(testData.fund.name);
+      FundDetails.waitLoading();
 
-    const CurrentBudgetDetails = FundDetails.openCurrentBudgetDetails();
-    CurrentBudgetDetails.waitLoading();
-    CurrentBudgetDetails.clickViewTransactionsLink();
-    Transactions.checkTransactionsList({
-      records: [{ type: 'Payment' }],
-      present: true,
-    });
-    Transactions.selectTransaction('Payment');
-    TransactionDetails.waitLoading();
-    TransactionDetails.checkTransactionDetails({
-      fiscalYear: testData.fiscalYear.code,
-      amount: '$10.00',
-      source: testData.invoice.vendorInvoiceNo,
-      type: 'Credit',
-      fund: `${testData.fund.name} (${testData.fund.code})`,
-    });
-  });
+      const CurrentBudgetDetails = FundDetails.openCurrentBudgetDetails();
+      CurrentBudgetDetails.waitLoading();
+      CurrentBudgetDetails.clickViewTransactionsLink();
+      Transactions.checkTransactionsList({
+        records: [{ type: 'Payment' }],
+        present: true,
+      });
+      Transactions.selectTransaction('Payment');
+      TransactionDetails.waitLoading();
+      TransactionDetails.checkTransactionDetails({
+        fiscalYear: testData.fiscalYear.code,
+        amount: '$10.00',
+        source: testData.invoice.vendorInvoiceNo,
+        type: 'Credit',
+        fund: `${testData.fund.name} (${testData.fund.code})`,
+      });
+    },
+  );
 });

--- a/cypress/e2e/invoices/save-invoice-FY-after-fund-change.cy.js
+++ b/cypress/e2e/invoices/save-invoice-FY-after-fund-change.cy.js
@@ -212,7 +212,7 @@ describe('Invoices', () => {
 
   it(
     'C388645 Save invoice fiscal year after fund distribution change if FY was undefined and pay invoice against previous FY (thunderjet) (TaaS)',
-    { tags: ['criticalPath', 'thunderjet', 'C388645'] },
+    { tags: ['criticalPath', 'thunderjet', 'C388645', 'nonParallel'] },
     () => {
       Invoices.createDefaultInvoiceWithoutAddress(testData.invoice);
       Invoices.checkCreatedInvoice({

--- a/cypress/e2e/invoices/save-invoice-fiscal-year-after-fund-distribution-change.cy.js
+++ b/cypress/e2e/invoices/save-invoice-fiscal-year-after-fund-distribution-change.cy.js
@@ -169,7 +169,7 @@ describe('Invoices', () => {
 
   it(
     'C396360 Save invoice fiscal year after fund distribution change to fund using different ledger if FY was undefined (thunderjet) (TaaS)',
-    { tags: ['criticalPath', 'thunderjet', 'C396360'] },
+    { tags: ['criticalPath', 'thunderjet', 'C396360', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(invoice.invoiceNumber);
       Invoices.selectInvoice(invoice.invoiceNumber);

--- a/cypress/e2e/invoices/user-is-not-able-to-approve-and-pay-invoice-created-in-the-past-when-associated-previous-budget-is-closed-extended.cy.js
+++ b/cypress/e2e/invoices/user-is-not-able-to-approve-and-pay-invoice-created-in-the-past-when-associated-previous-budget-is-closed-extended.cy.js
@@ -334,7 +334,7 @@ describe('Invoices', () => {
 
   it(
     'C396376 User is not able to approve and pay Invoice created in the past when associated previous budget is closed Extended (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C396376'] },
+    { tags: ['extendedPath', 'thunderjet', 'C396376', 'nonParallel'] },
     () => {
       Invoices.selectTagsFilter([testData.tag.label]);
       Invoices.checkSearchResultsContent({

--- a/cypress/e2e/invoices/user-is-not-able-to-approve-and-pay-invoice-created-in-the-past-when-invoice-amount-exceeds-available-budget-amount.cy.js
+++ b/cypress/e2e/invoices/user-is-not-able-to-approve-and-pay-invoice-created-in-the-past-when-invoice-amount-exceeds-available-budget-amount.cy.js
@@ -295,7 +295,7 @@ describe('Invoices', () => {
 
   it(
     'C389493 User is not able to approve and pay Invoice created in the past when Invoice amount exceeds available budget amount (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C389493'] },
+    { tags: ['extendedPath', 'thunderjet', 'C389493', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.invoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.invoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/user-is-not-able-to-approve-and-pay-invoice-when-related-budget-has-not-enough-money.cy.js
+++ b/cypress/e2e/invoices/user-is-not-able-to-approve-and-pay-invoice-when-related-budget-has-not-enough-money.cy.js
@@ -302,7 +302,7 @@ describe('Invoices', () => {
 
   it(
     'C396385 User is not able to approve and pay invoice when related budget has not enough money (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C396385'] },
+    { tags: ['extendedPath', 'thunderjet', 'C396385', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(testData.firstInvoice.vendorInvoiceNo);
       Invoices.selectInvoice(testData.firstInvoice.vendorInvoiceNo);

--- a/cypress/e2e/invoices/user-is-not-able-to-pay-previously-approved-invoice.cy.js
+++ b/cypress/e2e/invoices/user-is-not-able-to-pay-previously-approved-invoice.cy.js
@@ -129,7 +129,7 @@ describe('Invoices', () => {
 
   it(
     'C397330 User is not able to pay previously approved invoice when related order was unopened (thunderjet)',
-    { tags: ['criticalPath', 'thunderjet', 'C397330'] },
+    { tags: ['criticalPath', 'thunderjet', 'C397330', 'nonParallel'] },
     () => {
       Invoices.searchByNumber(invoice.invoiceNumber);
       Invoices.selectInvoice(invoice.invoiceNumber);

--- a/cypress/e2e/orders/encumbrance-status-unreleased-when-order-unopened-and-reopened.cy.js
+++ b/cypress/e2e/orders/encumbrance-status-unreleased-when-order-unopened-and-reopened.cy.js
@@ -237,7 +237,7 @@ describe('Orders', () => {
 
   it(
     'C451534 Encumbrance status is unreleased when an Order was unopened and then reopened and does not create an additional encumbrance (thunderjet)',
-    { tags: ['extendedPath', 'thunderjet', 'C451534'] },
+    { tags: ['extendedPath', 'thunderjet', 'C451534', 'nonParallel'] },
     () => {
       Orders.searchByParameter('PO number', testData.order.poNumber);
       Orders.selectFromResultsList(testData.order.poNumber);

--- a/cypress/e2e/orders/open-order-w-not-unique-po-line-title.cy.js
+++ b/cypress/e2e/orders/open-order-w-not-unique-po-line-title.cy.js
@@ -64,7 +64,7 @@ describe('Orders', () => {
 
   it(
     'C353562 User is able to open purchase order with NOT unique PO line title when "Disable duplicate check" option is enabled (thunderjet) (TaaS)',
-    { tags: ['extendedPath', 'thunderjet', 'C353562'] },
+    { tags: ['extendedPath', 'thunderjet', 'C353562', 'nonParallel'] },
     () => {
       // Search for the Order #1 from Preconditions and click on its record
       const OrderDetails = Orders.selectOrderByPONumber(testData.orders[0].poNumber);

--- a/cypress/e2e/orders/release-encumbrances-when-reopen-unreceived-one-time-order-with-approved-invoice-with-acquisition-unit.cy.js
+++ b/cypress/e2e/orders/release-encumbrances-when-reopen-unreceived-one-time-order-with-approved-invoice-with-acquisition-unit.cy.js
@@ -254,7 +254,7 @@ describe('Orders', () => {
 
   it(
     'C451635 Release encumbrances when reopen unreceived one-time order with related approved invoice with acquisition unit (Release encumbrance = true) (thunderjet)',
-    { tags: ['criticalPath', 'thunderjet', 'C451635'] },
+    { tags: ['criticalPath', 'thunderjet', 'C451635', 'nonParallel'] },
     () => {
       Orders.searchByParameter('PO number', testData.order.poNumber);
       Orders.selectFromResultsList(testData.order.poNumber);


### PR DESCRIPTION
"Approval" setting in the invoices app might cause test conflicts because it changes the UX. So the tests that require this setting should run consecutively (not in parallel).