### PR TITLE
FAT-28019-pt3: tests added

### DIFF
--- a/cypress/e2e/marc/marc-authority/create-marc-authority/cannot-create-marcAuth-record-with-multiple-not-repeatable-local-fields.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/cannot-create-marcAuth-record-with-multiple-not-repeatable-local-fields.cy.js
@@ -1,0 +1,153 @@
+import { DEFAULT_FOLIO_AUTHORITY_FILES } from '../../../../support/constants';
+import Permissions from '../../../../support/dictionary/permissions';
+import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
+import QuickMarcEditor from '../../../../support/fragments/quickMarcEditor';
+import TopMenu from '../../../../support/fragments/topMenu';
+import Users from '../../../../support/fragments/users/users';
+import {
+  getAuthoritySpec,
+  toggleAllUndefinedValidationRules,
+} from '../../../../support/api/specifications-helper';
+import getRandomPostfix, { randomNDigitNumber } from '../../../../support/utils/stringTools';
+
+describe('MARC', () => {
+  describe('MARC authority', () => {
+    describe('Create', () => {
+      const randomPostfix = getRandomPostfix();
+
+      const testData = {
+        tag008: '008',
+        tag010: '010',
+        tag100: '100',
+        tag980: '980',
+        folioAuthFile: DEFAULT_FOLIO_AUTHORITY_FILES.LC_NAME_AUTHORITY_FILE,
+        naturalId: `n${randomNDigitNumber(18)}552359`,
+        field100Content: `$a AT_C552359_MarcAuthority_${randomPostfix}`,
+        field100Ind1: '1',
+        field100Ind2: '\\',
+        field980Content1: '$a First not-repeatable field',
+        field980Content2: '$a Second not-repeatable field',
+        errorFieldNonRepeatable: 'Field is non-repeatable.',
+        field980SecondRowIndex: 7,
+      };
+
+      let user;
+      let authSpecId;
+      let localField980Id;
+
+      before('Get authority spec', () => {
+        cy.getAdminToken();
+        getAuthoritySpec().then((authSpec) => {
+          authSpecId = authSpec.id;
+          toggleAllUndefinedValidationRules(authSpecId, { enable: false });
+        });
+      });
+
+      after('Delete test data', () => {
+        cy.getAdminToken();
+        if (localField980Id) cy.deleteSpecificationField(localField980Id, false);
+        cy.syncSpecifications(authSpecId);
+        MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile, false);
+        if (user?.userId) Users.deleteViaApi(user.userId);
+      });
+
+      it(
+        'C552359 Cannot create MARC authority record with multiple not-repeatable "Local" fields (spitfire)',
+        { tags: ['criticalPath', 'spitfire', 'nonParallel', 'C552359'] },
+        () => {
+          cy.then(() => {
+            MarcAuthorities.deleteMarcAuthorityByTitleViaAPI('C552359_');
+
+            cy.deleteSpecificationFieldByTag(authSpecId, testData.tag980, false);
+            cy.createSpecificationField(authSpecId, {
+              tag: testData.tag980,
+              label: `AT_C552359_LocalField_980_${randomPostfix}`,
+              repeatable: false,
+              required: false,
+              deprecated: false,
+            }).then((resp) => {
+              localField980Id = resp.body.id;
+            });
+          })
+            .then(() => {
+              cy.createTempUser([
+                Permissions.uiMarcAuthoritiesAuthorityRecordView.gui,
+                Permissions.uiQuickMarcQuickMarcAuthorityCreate.gui,
+                Permissions.uiMarcAuthoritiesAuthorityRecordCreate.gui,
+              ]).then((userProperties) => {
+                user = userProperties;
+                MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile);
+                cy.login(user.username, user.password, {
+                  path: TopMenu.marcAuthorities,
+                  waiter: MarcAuthorities.waitLoading,
+                });
+              });
+            })
+            .then(() => {
+              // Step 1: Open new MARC authority record form
+              MarcAuthorities.clickActionsAndNewAuthorityButton();
+              QuickMarcEditor.checkPaneheaderContains(MarcAuthority.createAuthorityPaneTitleRegExp);
+              MarcAuthority.checkSourceFileSelectShown();
+
+              // Step 2: Select FOLIO authority file
+              MarcAuthority.selectSourceFile(testData.folioAuthFile);
+              MarcAuthority.verifySourceFileSelected(testData.folioAuthFile);
+
+              // Step 3: Set valid 008 dropdown values
+              MarcAuthority.setValid008DropdownValues();
+              QuickMarcEditor.checkSomeDropdownsMarkedAsInvalid(testData.tag008, false);
+
+              // Step 4: Add 010 field
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag008,
+                testData.tag010,
+                `$a ${testData.naturalId}`,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag010, `$a ${testData.naturalId}`);
+
+              // Step 5: Add 100 heading
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag010,
+                testData.tag100,
+                testData.field100Content,
+                testData.field100Ind1,
+                testData.field100Ind2,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag100, testData.field100Content);
+
+              // Step 6: Add first not-repeatable 980 field after 100
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag100,
+                testData.tag980,
+                testData.field980Content1,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag980, testData.field980Content1);
+
+              // Step 6 (cont): Add second not-repeatable 980 field after first 980
+              cy.wait(1000);
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag980,
+                testData.tag980,
+                testData.field980Content2,
+              );
+              QuickMarcEditor.checkContent(
+                testData.field980Content2,
+                testData.field980SecondRowIndex,
+              );
+
+              // Step 7: Save & close → inline fail error on second 980; toast shows 1 fail error
+              QuickMarcEditor.pressSaveAndCloseButton();
+              QuickMarcEditor.verifyValidationCallout(0, 1);
+              QuickMarcEditor.closeAllCallouts();
+              QuickMarcEditor.checkErrorMessage(
+                testData.field980SecondRowIndex,
+                testData.errorFieldNonRepeatable,
+              );
+              QuickMarcEditor.verifySaveAndCloseButtonEnabled(true);
+            });
+        },
+      );
+    });
+  });
+});

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-edit-marcAuth-record-with-backslash-in-fields.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-edit-marcAuth-record-with-backslash-in-fields.cy.js
@@ -1,0 +1,172 @@
+import { including } from '@interactors/html';
+import Permissions from '../../../../support/dictionary/permissions';
+import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
+import QuickMarcEditor from '../../../../support/fragments/quickMarcEditor';
+import ManageAuthorityFiles from '../../../../support/fragments/settings/marc-authority/manageAuthorityFiles';
+import TopMenu from '../../../../support/fragments/topMenu';
+import Users from '../../../../support/fragments/users/users';
+import getRandomPostfix, { getRandomLetters } from '../../../../support/utils/stringTools';
+
+describe('MARC', () => {
+  describe('MARC authority', () => {
+    describe('Create', () => {
+      const randomPostfix = getRandomPostfix();
+      const localAuthFile = {
+        name: `AT_C877079_AuthoritySourceFile_${randomPostfix}`,
+        prefix: getRandomLetters(18),
+        startWithNumber: '877079',
+        isActive: true,
+      };
+      const testData = {
+        tag008: '008',
+        tag010: '010',
+        tag100: '100',
+        tag400: '400',
+        naturalId: `${localAuthFile.prefix}${localAuthFile.startWithNumber}`,
+        field100SubfieldAContent: `AT_C877079_MarcAuthority_${randomPostfix} back\\slash in middle. Test slash at the \\start and end\\. Test \\ lonely. Te\\\\st multiple\\\\. Test \\\\ multiple`,
+        field400SubfieldAContent: 'test backsl\\ashes',
+      };
+
+      let user;
+      let createdAuthorityId;
+
+      before('Create test data', () => {
+        cy.getAdminToken();
+        MarcAuthorities.deleteMarcAuthorityByTitleViaAPI('C877079_');
+        cy.getAuthoritySourceFileDataViaAPI('AT_C877079_*').then(() => {
+          Cypress.env('authoritySourceFiles').forEach((sourceFile) => {
+            ManageAuthorityFiles.unsetAuthorityFileAsActiveViaApi(sourceFile.name);
+            cy.deleteAuthoritySourceFileViaAPI(sourceFile.id, true);
+          });
+        });
+
+        cy.createTempUser([
+          Permissions.uiMarcAuthoritiesAuthorityRecordView.gui,
+          Permissions.uiMarcAuthoritiesAuthorityRecordEdit.gui,
+          Permissions.uiQuickMarcQuickMarcAuthoritiesEditorAll.gui,
+          Permissions.uiQuickMarcQuickMarcAuthorityCreate.gui,
+          Permissions.uiMarcAuthoritiesAuthorityRecordCreate.gui,
+        ])
+          .then((userProperties) => {
+            user = userProperties;
+          })
+          .then(() => {
+            cy.createAuthoritySourceFileUsingAPI(
+              localAuthFile.prefix,
+              localAuthFile.startWithNumber,
+              localAuthFile.name,
+              localAuthFile.isActive,
+            ).then((sourceId) => {
+              localAuthFile.id = sourceId;
+            });
+          })
+          .then(() => {
+            // Wait for the scheduled job to process the new source file
+            cy.wait(70000);
+            cy.login(user.username, user.password, {
+              path: TopMenu.marcAuthorities,
+              waiter: MarcAuthorities.waitLoading,
+            });
+          });
+      });
+
+      after('Delete test data', () => {
+        cy.getAdminToken();
+        cy.deleteAuthoritySourceFileViaAPI(localAuthFile.id, true);
+        if (createdAuthorityId) MarcAuthority.deleteViaAPI(createdAuthorityId, true);
+        if (user?.userId) Users.deleteViaApi(user.userId);
+        cy.getAuthoritySourceFileDataViaAPI('AT_C877079_*').then(() => {
+          Cypress.env('authoritySourceFiles').forEach((sourceFile) => {
+            ManageAuthorityFiles.unsetAuthorityFileAsActiveViaApi(sourceFile.name);
+            cy.deleteAuthoritySourceFileViaAPI(sourceFile.id, true);
+          });
+        });
+      });
+
+      it(
+        'C877079 Create/Edit MARC authority record with backslash ("\\") character in some fields and check detail view pane (spitfire)',
+        { tags: ['extendedPath', 'spitfire', 'C877079'] },
+        () => {
+          // Step 1: Open new MARC authority record form
+          MarcAuthorities.clickActionsAndNewAuthorityButton();
+          QuickMarcEditor.checkPaneheaderContains(MarcAuthority.createAuthorityPaneTitleRegExp);
+          MarcAuthority.checkSourceFileSelectShown();
+
+          // Step 2: Select authority file and add 010 field
+          MarcAuthority.selectSourceFile(localAuthFile.name);
+          MarcAuthority.verifySourceFileSelected(localAuthFile.name);
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            testData.tag008,
+            testData.tag010,
+            `$a ${testData.naturalId}`,
+          );
+          QuickMarcEditor.checkContentByTag(testData.tag010, `$a ${testData.naturalId}`);
+
+          // Step 3: Set valid 008 dropdown values
+          MarcAuthority.setValid008DropdownValues();
+          QuickMarcEditor.checkSomeDropdownsMarkedAsInvalid(testData.tag008, false);
+
+          // Step 4: Add 100 field with backslash characters
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            testData.tag010,
+            testData.tag100,
+            `$a ${testData.field100SubfieldAContent}`,
+          );
+          QuickMarcEditor.checkContentByTag(
+            testData.tag100,
+            `$a ${testData.field100SubfieldAContent}`,
+          );
+
+          // Step 5: Save & keep editing → record saved; 100 content preserved unchanged
+          QuickMarcEditor.clickSaveAndKeepEditing();
+          QuickMarcEditor.checkAfterSaveAndKeepEditingDerive();
+          QuickMarcEditor.checkContentByTag(
+            testData.tag100,
+            `$a ${testData.field100SubfieldAContent}`,
+          );
+
+          // Step 6: Close pane; find record via search; verify heading in results and detail view
+          QuickMarcEditor.close();
+          MarcAuthority.waitLoading();
+          MarcAuthority.getId().then((id) => {
+            createdAuthorityId = id;
+          });
+          MarcAuthority.contains(`$a ${testData.field100SubfieldAContent}`);
+          MarcAuthority.closeAuthorityViewPane();
+          cy.wait(2000);
+
+          MarcAuthorities.searchBeats(testData.field100SubfieldAContent);
+          MarcAuthorities.checkRow(including(testData.field100SubfieldAContent));
+          MarcAuthorities.selectIncludingTitle(testData.field100SubfieldAContent);
+          MarcAuthority.waitLoading();
+          MarcAuthority.getId().then((id) => {
+            createdAuthorityId = id;
+          });
+          MarcAuthority.contains(`$a ${testData.field100SubfieldAContent}`);
+
+          // Step 7: Open edit mode
+          MarcAuthority.edit();
+
+          // Step 8: Add 400 field with backslash characters
+          MarcAuthority.addNewFieldAfterExistingByTag(
+            testData.tag100,
+            testData.tag400,
+            `$a ${testData.field400SubfieldAContent}`,
+          );
+          QuickMarcEditor.checkContentByTag(
+            testData.tag400,
+            `$a ${testData.field400SubfieldAContent}`,
+          );
+
+          // Step 9: Save & close → verify heading and field contents preserved in detail view and results
+          QuickMarcEditor.pressSaveAndClose();
+          MarcAuthority.waitLoading();
+          MarcAuthorities.checkRow(including(testData.field100SubfieldAContent));
+          MarcAuthority.contains(testData.field100SubfieldAContent);
+          MarcAuthority.contains(testData.field400SubfieldAContent);
+        },
+      );
+    });
+  });
+});

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-marcAuth-record-checked-against-last-version-validation-rules.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-marcAuth-record-checked-against-last-version-validation-rules.cy.js
@@ -1,0 +1,239 @@
+import { including } from '@interactors/html';
+import { DEFAULT_FOLIO_AUTHORITY_FILES } from '../../../../support/constants';
+import Permissions from '../../../../support/dictionary/permissions';
+import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
+import QuickMarcEditor from '../../../../support/fragments/quickMarcEditor';
+import TopMenu from '../../../../support/fragments/topMenu';
+import Users from '../../../../support/fragments/users/users';
+import {
+  getAuthoritySpec,
+  findStandardField,
+  findLocalField,
+  toggleAllUndefinedValidationRules,
+} from '../../../../support/api/specifications-helper';
+import getRandomPostfix, { randomNDigitNumber } from '../../../../support/utils/stringTools';
+
+describe('MARC', () => {
+  describe('MARC authority', () => {
+    describe('Create', () => {
+      const randomPostfix = getRandomPostfix();
+
+      const indicatorWarningText = (position, value) => `Warn: ${position === 0 ? 'First' : 'Second'} Indicator '${value}' is undefined.`;
+      const subfieldWarningText = (code) => `Warn: Subfield '${code}' is undefined.`;
+
+      const testData = {
+        tag008: '008',
+        tag010: '010',
+        tag100: '100',
+        tag500: '500',
+        tag948: '948',
+        folioAuthFile: DEFAULT_FOLIO_AUTHORITY_FILES.LC_NAME_AUTHORITY_FILE,
+        naturalId: `n${randomNDigitNumber(18)}552459`,
+        field100Content: `$a AT_C552459_MarcAuthority_${randomPostfix}`,
+        field100Ind1: '1',
+        field100Ind2: '\\',
+        field100UpdatedContent: `$a AT_C552459_MarcAuthority_${randomPostfix} test2`,
+        field948Content: '$a Undefined field',
+        field500Content: '$a Standard field',
+        field500Ind1: '1',
+        field500Ind2: '\\',
+        errorField500Required: 'Field 500 is required.',
+        errorField948Undefined: 'Warn: Field is undefined.',
+        tag948RowIndex: 6,
+      };
+
+      let user;
+      let authSpecId;
+      let createdAuthorityId;
+      let field500Id;
+      let field500OriginalData;
+      let field948Id;
+
+      before('Get authority spec', () => {
+        cy.getAdminToken();
+        getAuthoritySpec().then((authSpec) => {
+          authSpecId = authSpec.id;
+        });
+      });
+
+      after('Delete test data', () => {
+        cy.getAdminToken(false);
+        toggleAllUndefinedValidationRules(authSpecId, { enable: false });
+
+        if (field500Id && field500OriginalData) {
+          cy.updateSpecificationField(
+            field500Id,
+            { ...field500OriginalData, required: false },
+            false,
+          );
+        }
+        if (field948Id) cy.deleteSpecificationField(field948Id, false);
+
+        cy.syncSpecifications(authSpecId);
+
+        MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile, false);
+
+        if (createdAuthorityId) MarcAuthority.deleteViaAPI(createdAuthorityId, true);
+        if (user?.userId) Users.deleteViaApi(user.userId);
+      });
+
+      it(
+        'C552459 Verify that created MARC authority record is checked against the last version of MARC validation rules (spitfire)',
+        { tags: ['criticalPath', 'spitfire', 'nonParallel', 'C552459'] },
+        () => {
+          cy.then(() => {
+            MarcAuthorities.deleteMarcAuthorityByTitleViaAPI('C552459_');
+            toggleAllUndefinedValidationRules(authSpecId, { enable: true });
+
+            cy.getSpecificationFields(authSpecId).then((fieldsResp) => {
+              const field500 = findStandardField(fieldsResp.body.fields, testData.tag500);
+              field500Id = field500.id;
+              field500OriginalData = { ...field500 };
+
+              const existing948 = findLocalField(fieldsResp.body.fields, testData.tag948);
+              if (existing948) cy.deleteSpecificationField(existing948.id, false);
+            });
+          })
+            .then(() => {
+              cy.createTempUser([
+                Permissions.uiMarcAuthoritiesAuthorityRecordView.gui,
+                Permissions.uiQuickMarcQuickMarcAuthorityCreate.gui,
+                Permissions.uiMarcAuthoritiesAuthorityRecordCreate.gui,
+                Permissions.specificationStorageSpecificationItemGet.gui,
+                Permissions.specificationStorageSpecificationCollectionGet.gui,
+                Permissions.specificationStorageCreateSpecificationField.gui,
+                Permissions.specificationStorageGetSpecificationFields.gui,
+                Permissions.specificationStorageUpdateSpecificationField.gui,
+              ]).then((userProperties) => {
+                user = userProperties;
+                MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile);
+                cy.login(user.username, user.password, {
+                  path: TopMenu.marcAuthorities,
+                  waiter: MarcAuthorities.waitLoading,
+                });
+              });
+            })
+            .then(() => {
+              // Step 1: Open new MARC authority record form
+              MarcAuthorities.clickActionsAndNewAuthorityButton();
+              QuickMarcEditor.checkPaneheaderContains(MarcAuthority.createAuthorityPaneTitleRegExp);
+              MarcAuthority.checkSourceFileSelectShown();
+
+              // Step 2: Select FOLIO authority file
+              MarcAuthority.selectSourceFile(testData.folioAuthFile);
+              MarcAuthority.verifySourceFileSelected(testData.folioAuthFile);
+
+              // Step 3: Set valid 008 dropdown values
+              MarcAuthority.setValid008DropdownValues();
+              QuickMarcEditor.checkSomeDropdownsMarkedAsInvalid(testData.tag008, false);
+
+              // Step 4: Add 010 field
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag008,
+                testData.tag010,
+                `$a ${testData.naturalId}`,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag010, `$a ${testData.naturalId}`);
+
+              // Step 5: Add 100 heading
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag010,
+                testData.tag100,
+                testData.field100Content,
+                testData.field100Ind1,
+                testData.field100Ind2,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag100, testData.field100Content);
+
+              // Step 6: Add undefined 948 field
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag100,
+                testData.tag948,
+                testData.field948Content,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag948, testData.field948Content);
+
+              // Step 7: Save & close → 1 warn (948 field is undefined)
+              QuickMarcEditor.pressSaveAndCloseButton();
+              QuickMarcEditor.verifyValidationCallout(1);
+              QuickMarcEditor.closeAllCallouts();
+              QuickMarcEditor.checkWarningMessageForField(
+                testData.tag948RowIndex,
+                testData.errorField948Undefined,
+              );
+
+              // Step 8: Update $a subfield of 1XX field
+              QuickMarcEditor.updateExistingField(testData.tag100, testData.field100UpdatedContent);
+              QuickMarcEditor.checkContentByTag(testData.tag100, testData.field100UpdatedContent);
+            })
+            .then(() => {
+              // Step 9: Create specification field for 948 (define it as a local field)
+              cy.createSpecificationField(
+                authSpecId,
+                {
+                  tag: testData.tag948,
+                  label: `AT_C552459_Local_Field_948_${randomPostfix}`,
+                  url: 'http://www.example.org/field948.html',
+                  repeatable: true,
+                  required: false,
+                  deprecated: false,
+                },
+                false,
+              ).then((resp) => {
+                field948Id = resp.body.id;
+              });
+
+              // Step 10: Update field 500 to be required
+              cy.updateSpecificationField(
+                field500Id,
+                { ...field500OriginalData, required: true },
+                false,
+              );
+            })
+            .then(() => {
+              cy.wait(2000);
+
+              // Step 11: Save & close again → 1 fail (500 required) + 3 warns (948 ind/subfield undefined)
+              QuickMarcEditor.pressSaveAndCloseButton();
+              QuickMarcEditor.checkCallout(testData.errorField500Required);
+              QuickMarcEditor.verifyValidationCallout(3, 1);
+              QuickMarcEditor.closeAllCallouts();
+              QuickMarcEditor.checkWarningMessageForFieldByTag(
+                testData.tag948,
+                including(indicatorWarningText(0, '\\')),
+              );
+              QuickMarcEditor.checkWarningMessageForFieldByTag(
+                testData.tag948,
+                including(indicatorWarningText(1, '\\')),
+              );
+              QuickMarcEditor.checkWarningMessageForFieldByTag(
+                testData.tag948,
+                including(subfieldWarningText('a')),
+              );
+              QuickMarcEditor.verifySaveAndCloseButtonEnabled(true);
+
+              // Step 12: Add required 500 field
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag100,
+                testData.tag500,
+                testData.field500Content,
+                testData.field500Ind1,
+                testData.field500Ind2,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag500, testData.field500Content);
+
+              // Step 13: Save & close → record saved successfully
+              QuickMarcEditor.saveAndCloseWithValidationWarnings();
+              MarcAuthority.waitLoading();
+              MarcAuthority.contains(testData.field100UpdatedContent);
+              MarcAuthority.contains(testData.field500Content);
+              MarcAuthority.getId().then((id) => {
+                createdAuthorityId = id;
+              });
+            });
+        },
+      );
+    });
+  });
+});

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/create-marcAuth-record-with-not-repeatable-multiple-repeatable-fields.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/create-marcAuth-record-with-not-repeatable-multiple-repeatable-fields.cy.js
@@ -1,0 +1,207 @@
+import { DEFAULT_FOLIO_AUTHORITY_FILES } from '../../../../support/constants';
+import Permissions from '../../../../support/dictionary/permissions';
+import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
+import QuickMarcEditor from '../../../../support/fragments/quickMarcEditor';
+import TopMenu from '../../../../support/fragments/topMenu';
+import Users from '../../../../support/fragments/users/users';
+import {
+  getAuthoritySpec,
+  toggleAllUndefinedValidationRules,
+} from '../../../../support/api/specifications-helper';
+import getRandomPostfix, { randomNDigitNumber } from '../../../../support/utils/stringTools';
+
+describe('MARC', () => {
+  describe('MARC authority', () => {
+    describe('Create', () => {
+      const randomPostfix = getRandomPostfix();
+
+      const testData = {
+        tag008: '008',
+        tag010: '010',
+        tag100: '100',
+        tag400: '400',
+        folioAuthFile: DEFAULT_FOLIO_AUTHORITY_FILES.LC_NAME_AUTHORITY_FILE,
+        naturalId: `n${randomNDigitNumber(18)}514983`,
+        field100Content: `$a AT_C514983_MarcAuthority_${randomPostfix}`,
+        field100Ind1: '1',
+        field100Ind2: '\\',
+        field400Content1: '$a Repeatable reference 1',
+        field400Content2: '$a Repeatable reference 2',
+        localNotRepeatableFieldTag: '980',
+        localRepeatableFieldTag: '981',
+        field980Content: '$a Not-repeatable local',
+        field981Content1: '$a Repeatable local 1st',
+        field981Content2: '$a Repeatable local 2nd',
+      };
+
+      let createdAuthorityId;
+      let user;
+      let authSpecId;
+      let localField980Id;
+      let localField981Id;
+
+      before('Get authority spec', () => {
+        cy.getAdminToken();
+        getAuthoritySpec().then((authSpec) => {
+          authSpecId = authSpec.id;
+        });
+      });
+
+      after('Delete test data', () => {
+        cy.getAdminToken();
+        if (localField980Id) cy.deleteSpecificationField(localField980Id, false);
+        if (localField981Id) cy.deleteSpecificationField(localField981Id, false);
+        cy.syncSpecifications(authSpecId);
+        MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile, false);
+        if (createdAuthorityId) MarcAuthority.deleteViaAPI(createdAuthorityId, true);
+        if (user?.userId) Users.deleteViaApi(user.userId);
+      });
+
+      it(
+        'C514983 Create MARC authority record with not-repeatable / multiple repeatable fields (Standard and Local) (spitfire)',
+        { tags: ['criticalPath', 'spitfire', 'nonParallel', 'C514983'] },
+        () => {
+          cy.then(() => {
+            MarcAuthorities.deleteMarcAuthorityByTitleViaAPI('C514983_');
+          })
+            .then(() => {
+              // Create not-repeatable local field 980
+              cy.deleteSpecificationFieldByTag(
+                authSpecId,
+                testData.localNotRepeatableFieldTag,
+                false,
+              );
+              cy.createSpecificationField(authSpecId, {
+                tag: testData.localNotRepeatableFieldTag,
+                label: `AT_C514983_Local_Field_980_${randomPostfix}`,
+                repeatable: false,
+                required: false,
+                deprecated: false,
+              }).then((fieldResp) => {
+                localField980Id = fieldResp.body.id;
+              });
+
+              // Create repeatable local field 981
+              cy.deleteSpecificationFieldByTag(authSpecId, testData.localRepeatableFieldTag, false);
+              cy.createSpecificationField(authSpecId, {
+                tag: testData.localRepeatableFieldTag,
+                label: `AT_C514983_Local_Field_981_${randomPostfix}`,
+                repeatable: true,
+                required: false,
+                deprecated: false,
+              }).then((fieldResp) => {
+                localField981Id = fieldResp.body.id;
+              });
+            })
+            .then(() => {
+              cy.createTempUser([
+                Permissions.uiMarcAuthoritiesAuthorityRecordView.gui,
+                Permissions.uiQuickMarcQuickMarcAuthorityCreate.gui,
+                Permissions.uiMarcAuthoritiesAuthorityRecordCreate.gui,
+              ]).then((userProperties) => {
+                user = userProperties;
+                toggleAllUndefinedValidationRules(authSpecId, { enable: false });
+                MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile);
+                cy.login(user.username, user.password, {
+                  path: TopMenu.marcAuthorities,
+                  waiter: MarcAuthorities.waitLoading,
+                });
+              });
+            })
+            .then(() => {
+              // Step 1: Open new MARC authority record form
+              MarcAuthorities.clickActionsAndNewAuthorityButton();
+              QuickMarcEditor.checkPaneheaderContains(MarcAuthority.createAuthorityPaneTitleRegExp);
+              MarcAuthority.checkSourceFileSelectShown();
+
+              // Step 2: Select FOLIO authority file
+              MarcAuthority.selectSourceFile(testData.folioAuthFile);
+              MarcAuthority.verifySourceFileSelected(testData.folioAuthFile);
+
+              // Step 3: Set valid 008 dropdown values
+              MarcAuthority.setValid008DropdownValues();
+              QuickMarcEditor.checkSomeDropdownsMarkedAsInvalid(testData.tag008, false);
+
+              // Step 4: Add 010 field
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag008,
+                testData.tag010,
+                `$a ${testData.naturalId}`,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag010, `$a ${testData.naturalId}`);
+
+              // Step 5: Add 100 heading
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag010,
+                testData.tag100,
+                testData.field100Content,
+                testData.field100Ind1,
+                testData.field100Ind2,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag100, testData.field100Content);
+
+              // Step 6: Add repeatable/not-repeatable fields.
+              // Order of additions achieves final row sequence: 400(ref1), 400(ref2), 980, 981(1st), 981(2nd)
+              // First add 400(ref1), then 980 and 981 after it while only one 400 exists,
+              // then insert 400(ref2) after the first 400 (pushing 980/981 down),
+              // then insert 981(2nd) after the first 981.
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag100,
+                testData.tag400,
+                testData.field400Content1,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag400, testData.field400Content1);
+
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag400,
+                testData.localNotRepeatableFieldTag,
+                testData.field980Content,
+              );
+              QuickMarcEditor.checkContentByTag(
+                testData.localNotRepeatableFieldTag,
+                testData.field980Content,
+              );
+
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.localNotRepeatableFieldTag,
+                testData.localRepeatableFieldTag,
+                testData.field981Content1,
+              );
+              QuickMarcEditor.checkContentByTag(
+                testData.localRepeatableFieldTag,
+                testData.field981Content1,
+              );
+
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag400,
+                testData.tag400,
+                testData.field400Content2,
+              );
+              QuickMarcEditor.checkContent(testData.field400Content2, 7);
+
+              cy.wait(1000);
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.localRepeatableFieldTag,
+                testData.localRepeatableFieldTag,
+                testData.field981Content2,
+              );
+              QuickMarcEditor.checkContent(testData.field981Content2, 10);
+
+              // Step 7: Save & close → success toast; detail view pane opens with all fields
+              QuickMarcEditor.pressSaveAndClose();
+              MarcAuthority.waitLoading();
+              MarcAuthority.getId().then((id) => {
+                createdAuthorityId = id;
+              });
+              MarcAuthority.contains(testData.field400Content1);
+              MarcAuthority.contains(testData.field400Content2);
+              MarcAuthority.contains(testData.field980Content);
+              MarcAuthority.contains(testData.field981Content1);
+              MarcAuthority.contains(testData.field981Content2);
+            });
+        },
+      );
+    });
+  });
+});

--- a/cypress/e2e/marc/marc-authority/create-marc-authority/trigger-validation-errors-for-1xx-field-on-create-pane.cy.js
+++ b/cypress/e2e/marc/marc-authority/create-marc-authority/trigger-validation-errors-for-1xx-field-on-create-pane.cy.js
@@ -1,0 +1,215 @@
+import { DEFAULT_FOLIO_AUTHORITY_FILES } from '../../../../support/constants';
+import Permissions from '../../../../support/dictionary/permissions';
+import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
+import QuickMarcEditor from '../../../../support/fragments/quickMarcEditor';
+import TopMenu from '../../../../support/fragments/topMenu';
+import Users from '../../../../support/fragments/users/users';
+import {
+  getAuthoritySpec,
+  findStandardField,
+  findStandardSubfield,
+  toggleAllUndefinedValidationRules,
+} from '../../../../support/api/specifications-helper';
+import getRandomPostfix, { randomNDigitNumber } from '../../../../support/utils/stringTools';
+
+describe('MARC', () => {
+  describe('MARC authority', () => {
+    describe('Create', () => {
+      const randomPostfix = getRandomPostfix();
+
+      const testData = {
+        tag008: '008',
+        tag010: '010',
+        tag110: '110',
+        tag199: '199',
+        folioAuthFile: DEFAULT_FOLIO_AUTHORITY_FILES.LC_NAME_AUTHORITY_FILE,
+        naturalId: `n${randomNDigitNumber(18)}566596`,
+        field110Ind1: '$',
+        field110Ind2: '5',
+        field110Content: `$5 $a AT_C566596_MarcAuthority_${randomPostfix} $f NR subfield 1 $f NR subfield 2 $t subfield t $9 undefined subfield nine`,
+        field199Ind1: '1',
+        field199Ind2: '&',
+        field199Content: '$a Undefined 1XX field',
+        requiredSubfield: 'e',
+        row1XXIndex: 5,
+        row199Index: 6,
+      };
+
+      const validationMessages = {
+        secondIndicatorUndefined: "Warn: Second Indicator '5' is undefined.",
+        subfield9Undefined: "Warn: Subfield '9' is undefined.",
+        nonRepeatableRequired1XX: QuickMarcEditor.tag1XXNonRepeatableRequiredCalloutText,
+        indicatorInvalid:
+          "Fail: Indicator must contain one character and can only accept numbers 0-9, letters a-z or a '\\'.",
+
+        subfieldERequired: "Fail: Subfield 'e' is required.",
+        subfieldFNonRepeatable: QuickMarcEditor.getSubfieldNonRepeatableInlineErrorText('f'),
+        fieldUndefined: 'Warn: Field is undefined.',
+      };
+
+      let user;
+      let authSpecId;
+      let field110Id;
+      let subfieldEId;
+      let subfieldEOriginalData;
+
+      before('Get authority spec and create user', () => {
+        cy.getAdminToken();
+        getAuthoritySpec().then((authSpec) => {
+          authSpecId = authSpec.id;
+        });
+      });
+
+      after('Delete test data', () => {
+        cy.getAdminToken();
+        toggleAllUndefinedValidationRules(authSpecId, { enable: false });
+        if (subfieldEId && subfieldEOriginalData) {
+          cy.updateSpecificationSubfield(
+            subfieldEId,
+            { ...subfieldEOriginalData, required: false },
+            false,
+          );
+        }
+        cy.syncSpecifications(authSpecId);
+        MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile, false);
+        if (user?.userId) Users.deleteViaApi(user.userId);
+      });
+
+      // Will FAIL until this is fixed - https://folio-org.atlassian.net/browse/UIQM-833
+      it(
+        'C566596 Trigger validation errors for 1XX field of MARC authority record on "Create MARC authority record" pane (spitfire)',
+        { tags: ['extendedPath', 'spitfire', 'nonParallel', 'C566596'] },
+        () => {
+          cy.then(() => {
+            cy.createTempUser([
+              Permissions.uiMarcAuthoritiesAuthorityRecordView.gui,
+              Permissions.uiQuickMarcQuickMarcAuthorityCreate.gui,
+              Permissions.uiMarcAuthoritiesAuthorityRecordCreate.gui,
+            ]).then((userProperties) => {
+              user = userProperties;
+              MarcAuthorities.setAuthoritySourceFileActivityViaAPI(testData.folioAuthFile);
+            });
+          })
+            .then(() => {
+              cy.getSpecificationFields(authSpecId).then((fieldsResp) => {
+                const field110 = findStandardField(fieldsResp.body.fields, testData.tag110);
+                if (field110) {
+                  field110Id = field110.id;
+                  cy.getSpecificationFieldSubfields(field110Id).then((subfieldsResp) => {
+                    const subfieldE = findStandardSubfield(
+                      subfieldsResp.body.subfields,
+                      testData.requiredSubfield,
+                    );
+                    if (subfieldE) {
+                      subfieldEId = subfieldE.id;
+                      subfieldEOriginalData = { ...subfieldE };
+                      if (!subfieldE.required) {
+                        cy.updateSpecificationSubfield(
+                          subfieldEId,
+                          { ...subfieldE, required: true },
+                          false,
+                        );
+                      }
+                    }
+                  });
+                }
+              });
+            })
+            .then(() => {
+              toggleAllUndefinedValidationRules(authSpecId, { enable: true });
+            })
+            .then(() => {
+              cy.login(user.username, user.password, {
+                path: TopMenu.marcAuthorities,
+                waiter: MarcAuthorities.waitLoading,
+              });
+
+              // Step 1: Open new MARC authority record form
+              MarcAuthorities.clickActionsAndNewAuthorityButton();
+              QuickMarcEditor.checkPaneheaderContains(MarcAuthority.createAuthorityPaneTitleRegExp);
+              MarcAuthority.checkSourceFileSelectShown();
+
+              // Step 2: Select FOLIO authority file
+              MarcAuthority.selectSourceFile(testData.folioAuthFile);
+              MarcAuthority.verifySourceFileSelected(testData.folioAuthFile);
+
+              // Step 3: Set valid 008 dropdown values
+              MarcAuthority.setValid008DropdownValues();
+              QuickMarcEditor.checkSomeDropdownsMarkedAsInvalid(testData.tag008, false);
+
+              // Step 4: Add 010 field
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag008,
+                testData.tag010,
+                `$a ${testData.naturalId}`,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag010, `$a ${testData.naturalId}`);
+
+              // Step 5: Add 110 1XX with ind2=5 (undefined), duplicate $f (non-rep), undefined $9
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag010,
+                testData.tag110,
+                testData.field110Content,
+                testData.field110Ind1,
+                testData.field110Ind2,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag110, testData.field110Content);
+
+              // Step 6: Add undefined 199 field with invalid indicator '&'
+              MarcAuthority.addNewFieldAfterExistingByTag(
+                testData.tag110,
+                testData.tag199,
+                testData.field199Content,
+                testData.field199Ind1,
+                testData.field199Ind2,
+              );
+              QuickMarcEditor.checkContentByTag(testData.tag199, testData.field199Content);
+
+              // Step 7: Save & keep editing → validate inline errors and toast
+              QuickMarcEditor.clickSaveAndKeepEditingButton();
+
+              // Inline errors on the 110 (1XX) row
+              QuickMarcEditor.checkErrorMessage(
+                testData.row1XXIndex,
+                validationMessages.secondIndicatorUndefined,
+              );
+              QuickMarcEditor.checkErrorMessage(
+                testData.row1XXIndex,
+                validationMessages.subfield9Undefined,
+              );
+              QuickMarcEditor.checkErrorMessage(
+                testData.row1XXIndex,
+                validationMessages.nonRepeatableRequired1XX,
+              );
+              QuickMarcEditor.checkErrorMessage(
+                testData.row1XXIndex,
+                validationMessages.indicatorInvalid,
+              );
+              QuickMarcEditor.checkErrorMessage(
+                testData.row1XXIndex,
+                validationMessages.subfieldERequired,
+              );
+              QuickMarcEditor.checkErrorMessage(
+                testData.row1XXIndex,
+                validationMessages.subfieldFNonRepeatable,
+              );
+
+              // Inline errors on the 199 row
+              QuickMarcEditor.checkErrorMessage(
+                testData.row199Index,
+                validationMessages.fieldUndefined,
+              );
+              QuickMarcEditor.checkErrorMessage(
+                testData.row199Index,
+                validationMessages.nonRepeatableRequired1XX,
+              );
+
+              // Toast: Warn errors: 3, Fail errors: 5
+              QuickMarcEditor.verifyValidationCallout(3, 5);
+            });
+        },
+      );
+    });
+  });
+});

--- a/cypress/e2e/marc/marc-authority/detail-view-pane/displaying-detail-view-pane-when-search-returns-1-record.cy.js
+++ b/cypress/e2e/marc/marc-authority/detail-view-pane/displaying-detail-view-pane-when-search-returns-1-record.cy.js
@@ -1,0 +1,122 @@
+import { MARC_AUTHORITY_SEARCH_OPTIONS } from '../../../../support/constants';
+import Permissions from '../../../../support/dictionary/permissions';
+import MarcAuthorities from '../../../../support/fragments/marcAuthority/marcAuthorities';
+import MarcAuthoritiesSearch from '../../../../support/fragments/marcAuthority/marcAuthoritiesSearch';
+import MarcAuthority from '../../../../support/fragments/marcAuthority/marcAuthority';
+import TopMenu from '../../../../support/fragments/topMenu';
+import Users from '../../../../support/fragments/users/users';
+import getRandomPostfix, { getRandomLetters } from '../../../../support/utils/stringTools';
+
+describe('MARC', () => {
+  describe('MARC authority', () => {
+    describe('Detail view pane', () => {
+      const randomPostfix = getRandomPostfix();
+      const authData = {
+        prefix: getRandomLetters(17),
+        startWithNumber: 3509640,
+      };
+      const testData = {
+        authorityHeadingPrefix: `AT_C350964_MarcAuthority_${randomPostfix}`,
+      };
+
+      const authorityHeadings = [
+        `${testData.authorityHeadingPrefix}_1`,
+        `${testData.authorityHeadingPrefix}_2`,
+        `${testData.authorityHeadingPrefix}_3`,
+      ];
+
+      const authorityFields = [
+        [
+          {
+            tag: '151',
+            content: `$a ${authorityHeadings[0]}`,
+            indicators: ['\\', '\\'],
+          },
+        ],
+        [
+          {
+            tag: '100',
+            content: `$a ${authorityHeadings[1]}`,
+            indicators: ['\\', '\\'],
+          },
+        ],
+        [
+          {
+            tag: '110',
+            content: `$a ${authorityHeadings[2]}`,
+            indicators: ['\\', '\\'],
+          },
+        ],
+      ];
+
+      const createdAuthorityIds = [];
+      let user;
+
+      before('Create test data', () => {
+        cy.getAdminToken();
+        MarcAuthorities.deleteMarcAuthorityByTitleViaAPI('C350964_');
+
+        cy.createTempUser([Permissions.uiMarcAuthoritiesAuthorityRecordView.gui])
+          .then((userProperties) => {
+            user = userProperties;
+          })
+          .then(() => {
+            authorityFields.forEach((fields, index) => {
+              MarcAuthorities.createMarcAuthorityViaAPI(
+                authData.prefix,
+                authData.startWithNumber + index,
+                fields,
+              ).then((authorityId) => {
+                createdAuthorityIds.push(authorityId);
+              });
+            });
+          })
+          .then(() => {
+            cy.login(user.username, user.password, {
+              path: TopMenu.marcAuthorities,
+              waiter: MarcAuthorities.waitLoading,
+            });
+          });
+      });
+
+      after('Delete test data', () => {
+        cy.getAdminToken();
+        createdAuthorityIds.forEach((authorityId) => {
+          MarcAuthority.deleteViaAPI(authorityId, true);
+        });
+        if (user?.userId) Users.deleteViaApi(user.userId);
+      });
+
+      it(
+        'C350964 Displaying detail view pane automatically when search return 1 record (spitfire)',
+        { tags: ['extendedPath', 'spitfire', 'C350964'] },
+        () => {
+          // Steps 1-3: Search with unique heading → 1 result → detail view opens automatically
+          MarcAuthoritiesSearch.searchBy(
+            MARC_AUTHORITY_SEARCH_OPTIONS.GEOGRAPHIC_NAME,
+            authorityHeadings[0],
+          );
+          MarcAuthorities.checkRowsCount(1);
+          MarcAuthority.waitLoading();
+          MarcAuthority.contains(authorityHeadings[0]);
+          MarcAuthorities.checkRowUpdatedAndHighlighted(authorityHeadings[0]);
+          MarcAuthority.checkViewPaneInFocus();
+
+          // Step 4: Close detail view → only 1 result remains in list; detail pane is closed
+          MarcAuthority.closeAuthorityViewPane();
+          MarcAuthorities.checkRowsCount(1);
+
+          // Steps 5-6: Search to get multiple records; click any → detail view opens
+          MarcAuthorities.searchBy(
+            MARC_AUTHORITY_SEARCH_OPTIONS.KEYWORD,
+            testData.authorityHeadingPrefix,
+          );
+          MarcAuthorities.checkRowsCountExistance(3);
+          MarcAuthorities.selectFirstRecord();
+          MarcAuthority.waitLoading();
+          MarcAuthority.checkViewPaneInFocus();
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
FAT ticket(s):
- https://folio-org.atlassian.net/browse/FAT-28019 (part 3, final)

Test case(s):
- https://foliotest.testrail.io/index.php?/cases/view/514983
- https://foliotest.testrail.io/index.php?/cases/view/552359
- https://foliotest.testrail.io/index.php?/cases/view/552459
- https://foliotest.testrail.io/index.php?/cases/view/566596
- https://foliotest.testrail.io/index.php?/cases/view/877079
- https://foliotest.testrail.io/index.php?/cases/view/350964

<details>
  <summary>Results - expand to see</summary>

<img width="1877" height="827" alt="Screenshot 2026-08-13 140756" src="https://github.com/user-attachments/assets/eefc3a8f-94ce-49ef-86cc-fad0655ea67a" />
<img width="1869" height="820" alt="Screenshot 2026-08-13 151117" src="https://github.com/user-attachments/assets/0f0052e1-3259-4bf5-878f-26aba21815be" />
<img width="1869" height="822" alt="Screenshot 2026-08-13 164716" src="https://github.com/user-attachments/assets/27b54ce2-f364-4552-9c1c-677d40ddae3c" />
<img width="1873" height="822" alt="Screenshot 2026-08-13 175147" src="https://github.com/user-attachments/assets/a7f0ec74-ecc5-452b-8be1-80ec8058a863" />
<img width="1872" height="825" alt="Screenshot 2026-08-13 183337" src="https://github.com/user-attachments/assets/b3e0a33c-1c23-4d70-a425-195469914fa6" />
<img width="1871" height="821" alt="Screenshot 2026-08-13 185002" src="https://github.com/user-attachments/assets/e02d1b95-61c8-4ba9-aee1-9bb1f248fc46" />

</details>
