### PR TITLE
Update policy template after functional changes.

### DIFF
--- a/cypress/e2e/circulation-log/filter-notice-send.cy.js
+++ b/cypress/e2e/circulation-log/filter-notice-send.cy.js
@@ -184,7 +184,7 @@ describe('Circulation log', () => {
           name: testData.templateData.name,
           description: testData.templateData.description,
           category: { requestId: testData.templateData.category },
-          subject: 'Subject_Test',
+          noticeFormat: 'Email',
           body: 'Test_email_body{{item.title}}',
         });
       });

--- a/cypress/e2e/patron-notices/create-patron-notice-template.cy.js
+++ b/cypress/e2e/patron-notices/create-patron-notice-template.cy.js
@@ -27,7 +27,6 @@ describe('Patron notices', () => {
       () => {
         NewNoticePolicyTemplate.startAdding();
         NewNoticePolicyTemplate.checkInitialState();
-        NewNoticePolicyTemplate.addToken('item.title');
         NewNoticePolicyTemplate.create(patronNoticeTemplate);
         NewNoticePolicyTemplate.checkAfterSaving(patronNoticeTemplate);
         NewNoticePolicyTemplate.checkTemplateActions(patronNoticeTemplate);

--- a/cypress/e2e/patron-notices/metadata-info-patron-notice-templates.cy.js
+++ b/cypress/e2e/patron-notices/metadata-info-patron-notice-templates.cy.js
@@ -49,7 +49,6 @@ describe('Patron notices', () => {
           name: noticeTemplate.name,
           description: noticeTemplate.description,
           category: NOTICE_CATEGORIES.loan,
-          subject: 'Email subject: Loan',
           body: 'Email body {{item.title}}',
         });
         NewNoticePolicyTemplate.editTemplate(noticeTemplate.name);
@@ -59,7 +58,6 @@ describe('Patron notices', () => {
           name: noticeTemplate.name,
           description: noticeTemplate.description,
           category: NOTICE_CATEGORIES.loan,
-          subject: 'Email subject: Loan',
           body: newBodytext,
         });
         cy.wait(2000);

--- a/cypress/e2e/patron-notices/patron-notice-duplication-works-as-expected.cy.js
+++ b/cypress/e2e/patron-notices/patron-notice-duplication-works-as-expected.cy.js
@@ -69,7 +69,6 @@ describe('Patron notices', () => {
         name: newNoticeTemplateName,
         description: testData.noticeTemplateBody.description,
         category: NOTICE_CATEGORIES.loan,
-        subject: 'Email subject: Loan',
         body: 'Email body {{item.title}}',
       });
     },

--- a/cypress/e2e/patron-notices/receive-notice-checkin.cy.js
+++ b/cypress/e2e/patron-notices/receive-notice-checkin.cy.js
@@ -220,8 +220,6 @@ describe('Patron notices', () => {
       () => {
         NewNoticePolicyTemplate.startAdding();
         NewNoticePolicyTemplate.checkInitialState();
-        NewNoticePolicyTemplate.addToken(testData.noticePolicyTemplateToken);
-        noticePolicyTemplate.body += '{{item.title}}';
         NewNoticePolicyTemplate.create(noticePolicyTemplate);
         NewNoticePolicyTemplate.checkAfterSaving(noticePolicyTemplate);
         NewNoticePolicyTemplate.checkTemplateActions(noticePolicyTemplate);

--- a/cypress/e2e/patron-notices/recieve-notice-checkin.cy.js
+++ b/cypress/e2e/patron-notices/recieve-notice-checkin.cy.js
@@ -221,8 +221,6 @@ describe('Patron notices', () => {
       () => {
         NewNoticePolicyTemplate.startAdding();
         NewNoticePolicyTemplate.checkInitialState();
-        NewNoticePolicyTemplate.addToken(testData.noticePolicyTemplateToken);
-        noticePolicyTemplate.body += '{{item.title}}';
         NewNoticePolicyTemplate.create(noticePolicyTemplate);
         NewNoticePolicyTemplate.checkAfterSaving(noticePolicyTemplate);
         NewNoticePolicyTemplate.checkTemplateActions(noticePolicyTemplate);

--- a/cypress/e2e/users/edit-user-datails.cy.js
+++ b/cypress/e2e/users/edit-user-datails.cy.js
@@ -26,7 +26,7 @@ describe('Users', () => {
       birthDate: '12/12/2000',
       phone: '1234567890',
       mobilePhone: '2345678901',
-      preferredContact: 'Text Message',
+      preferredContact: 'SMS text',
       status: 'Inactive',
     },
   };

--- a/cypress/support/fragments/settings/circulation/patron-notices/newNoticePolicyTemplate.js
+++ b/cypress/support/fragments/settings/circulation/patron-notices/newNoticePolicyTemplate.js
@@ -79,6 +79,7 @@ export default {
       description: 'Template created by autotest team',
       subject: 'Subject_Test',
       body: 'Test_email_body',
+      noticeFormat: 'Email',
     };
   },
 
@@ -253,7 +254,7 @@ export default {
       name: noticePolicyTemplate.name,
       description: noticePolicyTemplate.description,
       category: noticePolicyTemplate.category.requestId,
-      noticeFormat: noticePolicyTemplate.noticeFormat,
+      noticeFormat: noticePolicyTemplate.noticeFormat || 'Email',
       body: noticePolicyTemplate.body,
     };
     Object.values(propertiesToCheck).forEach((prop) => {
@@ -296,6 +297,9 @@ export default {
     cy.do(descriptionField.fillIn('Test'));
     cy.expect(descriptionField.has({ value: 'Test' }));
 
+    cy.do(noticeFormatField.choose('Email'));
+
+    cy.expect(subjectField.has({ disabled: false }));
     cy.do(subjectField.fillIn(''));
     cy.wait(1000);
     cy.do(bodyField.fillIn('Test'));
@@ -310,6 +314,9 @@ export default {
     cy.do(nameField.fillIn('Test'));
     cy.expect(nameField.has({ value: 'Test' }));
 
+    cy.do(noticeFormatField.choose('Email'));
+
+    cy.expect(subjectField.has({ disabled: false }));
     cy.do(descriptionField.fillIn('Test'));
     cy.expect(descriptionField.has({ value: 'Test' }));
 

--- a/cypress/support/fragments/settings/circulation/patron-notices/noticeTemplates.js
+++ b/cypress/support/fragments/settings/circulation/patron-notices/noticeTemplates.js
@@ -40,13 +40,13 @@ export default {
   },
   collapseAll() {
     cy.do(Button('Collapse all').click());
-    cy.wrap(['General information', 'Email or print']).each((accordion) => {
+    cy.wrap(['General information', 'Patron notice content']).each((accordion) => {
       cy.expect(Button(accordion).has({ ariaExpanded: 'false' }));
     });
   },
   expandAll() {
     cy.do(Button('Expand all').click());
-    cy.wrap(['General information', 'Email or print']).each((accordion) => {
+    cy.wrap(['General information', 'Patron notice content']).each((accordion) => {
       cy.expect(Button(accordion).has({ ariaExpanded: 'true' }));
     });
   },


### PR DESCRIPTION
## Description
Functional changes have been introduced in https://folio-org.atlassian.net/browse/UICIRC-1350:
- The subject field has been removed from the details page of the notice template, and the notice format field has been added;
- The `NewNoticePolicyTemplate.addToken` has been removed since `NewNoticePolicyTemplate.create` already adds the token;
- `preferredContact` (`Text Message`) has been renamed to the `SMS text`;
- The `Email or print` accordion has been renamed to the `Patron notice content`.